### PR TITLE
Chore/lint fix

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,8 +15,9 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    "src/shared/graphql/generated/**",
   ]),
-  ...storybook.configs["flat/recommended"]
+  ...storybook.configs["flat/recommended"],
 ]);
 
 export default eslintConfig;

--- a/src/components/commons/comment/commentList/CommentList.tsx
+++ b/src/components/commons/comment/commentList/CommentList.tsx
@@ -3,17 +3,18 @@ import { MessageCircle } from "lucide-react";
 import CommentItem from "../commentItem/CommentItem";
 
 export default function CommentList({
-  // isLoading,
+  isLoading,
   comments,
   subText = "이 기록에 대한 생각을 공유해주세요",
 }: {
-  isLoading: boolean;
+  isLoading?: boolean;
   comments: Array<IBoardComment>;
   subText?: string;
 }) {
   // TODO: skeleton 구현
-  // if (isLoading) {
-  // }
+  if (isLoading) {
+    <div>로딩 중...</div>;
+  }
 
   if (comments.length === 0) {
     return (

--- a/src/components/commons/modal/placeSearchModal/PlaceSearchModal.stories.tsx
+++ b/src/components/commons/modal/placeSearchModal/PlaceSearchModal.stories.tsx
@@ -2,14 +2,13 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import React, { useEffect, useState } from "react";
 import PlaceSearchModal from "./PlaceSearchModal";
 import { Button } from "@/components/ui/button/Button";
+import { KakaoPlace } from "@/shared/types/kakao";
 
-type KakaoPlace = {
-  id: string;
-  place_name: string;
-  address_name: string;
-  road_address_name: string;
-  x: string;
-  y: string;
+// ✅ 스토리 전용 타입 분리
+type MockMode = "success" | "error" | "empty" | "slow";
+
+type StoryArgs = React.ComponentProps<typeof PlaceSearchModal> & {
+  mockMode: MockMode;
 };
 
 const MOCK_PLACES: KakaoPlace[] = [
@@ -39,20 +38,20 @@ const MOCK_PLACES: KakaoPlace[] = [
   },
 ];
 
-function installFetchMock({
-  mode,
-}: {
-  mode: "success" | "error" | "empty" | "slow";
-}) {
+function installFetchMock(mode: MockMode) {
   const original = window.fetch.bind(window);
 
-  window.fetch = (async (input: any, init?: any) => {
-    const url = typeof input === "string" ? input : input?.url ?? "";
+  window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.href
+        : (input as Request).url;
 
     if (url.startsWith("/api/kakao/places")) {
-      if (mode === "slow") {
-        await new Promise((r) => setTimeout(r, 1200));
-      }
+      if (mode === "slow") await new Promise((r) => setTimeout(r, 1200));
+
       if (mode === "error") {
         return new Response(JSON.stringify({ message: "Mock 검색 실패" }), {
           status: 500,
@@ -65,7 +64,6 @@ function installFetchMock({
           headers: { "Content-Type": "application/json" },
         });
       }
-      // success
       return new Response(JSON.stringify({ documents: MOCK_PLACES }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -73,14 +71,15 @@ function installFetchMock({
     }
 
     return original(input, init);
-  }) as any;
+  }) as typeof window.fetch;
 
   return () => {
     window.fetch = original;
   };
 }
 
-const meta: Meta<typeof PlaceSearchModal> = {
+// ✅ StoryArgs 타입 사용
+const meta: Meta<StoryArgs> = {
   title: "commons/modal/PlaceSearchModal",
   component: PlaceSearchModal,
   parameters: { layout: "fullscreen" },
@@ -88,20 +87,16 @@ const meta: Meta<typeof PlaceSearchModal> = {
     open: { control: false },
     onOpenChange: { control: false },
     onConfirm: { action: "confirm(place)" },
-    closeOnOverlayClick: { control: "boolean" },
     className: { control: "text" },
-    // story 전용
-    __mockMode: {
-      name: "mockMode",
+    mockMode: {
       control: "inline-radio",
-      options: ["success", "empty", "error", "slow"],
+      options: ["success", "empty", "error", "slow"] satisfies MockMode[],
     },
-  } as any,
+  },
   args: {
-    closeOnOverlayClick: true,
     className: "",
-    __mockMode: "success",
-  } as any,
+    mockMode: "success",
+  },
   decorators: [
     (Story) => (
       <div className="min-h-screen bg-background p-8">
@@ -115,17 +110,17 @@ const meta: Meta<typeof PlaceSearchModal> = {
     ),
   ],
 };
+
 export default meta;
 
-type Story = StoryObj<typeof PlaceSearchModal>;
+type Story = StoryObj<StoryArgs>;
 
-function Demo(props: any) {
+function Demo({ mockMode, ...props }: StoryArgs) {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    const uninstall = installFetchMock({ mode: props.__mockMode });
-    return uninstall;
-  }, [props.__mockMode]);
+    return installFetchMock(mockMode);
+  }, [mockMode]);
 
   return (
     <>
@@ -134,14 +129,13 @@ function Demo(props: any) {
           장소 검색 모달 열기
         </Button>
       </div>
-
       <PlaceSearchModal
+        {...props}
         open={open}
         onOpenChange={setOpen}
-        closeOnOverlayClick={props.closeOnOverlayClick}
-        className={props.className}
         onConfirm={(place) => {
           props.onConfirm?.(place);
+          setOpen(false);
         }}
       />
     </>
@@ -152,22 +146,17 @@ export const Playground: Story = {
   render: (args) => <Demo {...args} />,
 };
 
-export const OverlayLocked: Story = {
-  args: { closeOnOverlayClick: false, __mockMode: "success" } as any,
-  render: (args) => <Demo {...args} />,
-};
-
 export const EmptyResult: Story = {
-  args: { __mockMode: "empty" } as any,
+  args: { mockMode: "empty" },
   render: (args) => <Demo {...args} />,
 };
 
 export const ErrorState: Story = {
-  args: { __mockMode: "error" } as any,
+  args: { mockMode: "error" },
   render: (args) => <Demo {...args} />,
 };
 
 export const SlowNetwork: Story = {
-  args: { __mockMode: "slow" } as any,
+  args: { mockMode: "slow" },
   render: (args) => <Demo {...args} />,
 };

--- a/src/components/commons/modal/placeSearchModal/PlaceSearchModal.tsx
+++ b/src/components/commons/modal/placeSearchModal/PlaceSearchModal.tsx
@@ -14,13 +14,11 @@ import { KakaoPlace } from "@/shared/types/kakao";
 export default function PlaceSearchModal({
   open,
   onOpenChange,
-  closeOnOverlayClick = true,
   onConfirm,
   className,
 }: {
   open: boolean;
   onOpenChange: (v: boolean) => void;
-  closeOnOverlayClick?: boolean;
   onConfirm: (place: KakaoPlace) => void;
   className?: string;
 }) {
@@ -60,12 +58,7 @@ export default function PlaceSearchModal({
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay
-          className="fixed inset-0 z-50 bg-black/50"
-          onPointerDown={(e) => {
-            if (!closeOnOverlayClick) e.preventDefault();
-          }}
-        />
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
 
         <div className="fixed inset-0 z-[60] flex items-end sm:items-center sm:justify-center p-0 sm:p-4">
           <Dialog.Content

--- a/src/components/features/home/HomeDashBoard/KeywordDashBoard/KeywordItem.tsx
+++ b/src/components/features/home/HomeDashBoard/KeywordDashBoard/KeywordItem.tsx
@@ -42,7 +42,9 @@ export default function KeywordItem({
   variant: KeywordVariant;
 }): JSX.Element {
   // TODO: 키워드 클릭 시 해당 키워드로 검색 페이지 이동 (현재는 클릭 이벤트만 정의)
-  const onKeywordClick = (name: string) => {};
+  const onKeywordClick = (name: string) => {
+    console.log(name);
+  };
 
   const c = colors[variant];
 

--- a/src/components/features/record-comments/RecordComments.tsx
+++ b/src/components/features/record-comments/RecordComments.tsx
@@ -11,6 +11,7 @@ import {
   useUpdateRecordComment,
 } from "./hooks";
 import { useConfirmPreset } from "@/shared/hooks/ui/useConfirmPreset";
+import { useInfiniteScroll } from "@/shared/hooks/ui/useInfiniteScroll";
 
 export default function RecordComments() {
   const router = useRouter();
@@ -27,9 +28,7 @@ export default function RecordComments() {
 
   const { openConfirmPreset } = useConfirmPreset();
 
-  // TODO: 댓글 무한스크롤 처리 (fetchMore, hasMore 등)
-  const { data, fetchMore, refetch, loading } =
-    useFetchRecordComments(recordId);
+  const { data, loading, hasMore, loadMore } = useFetchRecordComments(recordId);
 
   const { onCreateRecordComment } = useCreateRecordComment({
     recordId,
@@ -42,7 +41,6 @@ export default function RecordComments() {
   const comments = data?.fetchBoardComments ?? [];
 
   const requestDeleteComment = (commentId: string) => {
-    // setTargetCommentId(commentId);
     openConfirmPreset("deleteComment", {
       onConfirm: async () => {
         await onDeleteRecordComment(commentId);
@@ -54,6 +52,12 @@ export default function RecordComments() {
     if (!IsLoggedIn) return;
     onCreateRecordComment({ contents });
   };
+
+  const targetRef = useInfiniteScroll({
+    hasMore,
+    isLoading: loading,
+    onLoadMore: loadMore,
+  });
 
   return (
     <>
@@ -71,7 +75,14 @@ export default function RecordComments() {
         >
           <CommentList isLoading={loading} comments={comments} />
         </CommentActionsProvider>
-        <CommentInput onSubmit={onSubmit} isLoggedIn={true} />
+        {hasMore && <div ref={targetRef} className="h-6" />}
+        {loading && (
+          <p className="text-xs text-center text-muted-foreground py-2">
+            댓글을 불러오는 중...
+          </p>
+        )}
+
+        <CommentInput onSubmit={onSubmit} isLoggedIn={IsLoggedIn} />
       </div>
     </>
   );

--- a/src/components/features/record-comments/hooks/mutations/useDeleteRecordComment.tsx
+++ b/src/components/features/record-comments/hooks/mutations/useDeleteRecordComment.tsx
@@ -4,6 +4,7 @@ import {
   IMutationDeleteBoardCommentArgs,
 } from "@/shared/graphql/generated/types";
 import { gql, useMutation } from "@apollo/client";
+import type { Reference, StoreObject } from "@apollo/client";
 
 const DELETE_RECORD_COMMENT = gql`
   mutation deleteBoardComment($password: String, $boardCommentId: ID!) {
@@ -26,9 +27,12 @@ export const useDeleteRecordComment = ({ password }: { password: string }) => {
         update(cache) {
           cache.modify({
             fields: {
-              fetchBoardComments(existing = [], { readField }) {
+              fetchBoardComments(
+                existing: ReadonlyArray<Reference | StoreObject> = [],
+                { readField }
+              ) {
                 return existing.filter(
-                  (ref: any) => readField("_id", ref) !== commentId
+                  (ref) => readField("_id", ref) !== commentId
                 );
               },
             },

--- a/src/components/features/record-comments/hooks/queries/useFetchRecordComments.ts
+++ b/src/components/features/record-comments/hooks/queries/useFetchRecordComments.ts
@@ -3,6 +3,7 @@ import {
   IQueryFetchBoardCommentsArgs,
 } from "@/shared/graphql/generated/types";
 import { gql, useQuery } from "@apollo/client";
+import { useState } from "react";
 
 const FETCH_RECORD_COMMENTS = gql`
   query fetchBoardComments($page: Int, $boardId: ID!) {
@@ -23,8 +24,13 @@ const FETCH_RECORD_COMMENTS = gql`
   }
 `;
 
+const PAGE_SIZE = 10;
+
 export const useFetchRecordComments = (recordId?: string) => {
-  return useQuery<
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+
+  const { data, loading, fetchMore, refetch } = useQuery<
     Pick<IQuery, "fetchBoardComments">,
     IQueryFetchBoardCommentsArgs
   >(FETCH_RECORD_COMMENTS, {
@@ -33,5 +39,42 @@ export const useFetchRecordComments = (recordId?: string) => {
       page: 1,
     },
     skip: !recordId,
+    onCompleted: (result) => {
+      if ((result.fetchBoardComments?.length ?? 0) < PAGE_SIZE) {
+        setHasMore(false);
+      }
+    },
   });
+
+  const loadMore = async () => {
+    if (!hasMore || loading) return;
+
+    const nextPage = page + 1;
+    const result = await fetchMore({
+      variables: { boardId: recordId ?? "", page: nextPage },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+
+        const newComments = fetchMoreResult.fetchBoardComments ?? [];
+        if (newComments.length < PAGE_SIZE) setHasMore(false);
+
+        return {
+          fetchBoardComments: [
+            ...(prev.fetchBoardComments ?? []),
+            ...newComments,
+          ],
+        };
+      },
+    });
+
+    if (result) setPage(nextPage);
+  };
+
+  return {
+    data,
+    loading,
+    hasMore,
+    loadMore,
+    refetch,
+  };
 };

--- a/src/components/features/record/detail/RecordDetail.tsx
+++ b/src/components/features/record/detail/RecordDetail.tsx
@@ -3,9 +3,9 @@ import { useRouter } from "next/router";
 import RecordDetailContent from "./recordDetailContent/RecordDetailContent";
 import ImageCarousel from "@/components/commons/imageCarousel/ImageCarousel";
 import BackButton from "@/components/commons/backButton/BackButton";
-import { useRecoilValue } from "recoil";
-import { loggedInUserState } from "@/shared/stores";
-import { useFetchRecordsOfMine } from "@/shared/hooks/record/useFetchRecordsOfMine";
+// import { useRecoilValue } from "recoil";
+// import { loggedInUserState } from "@/shared/stores";
+// import { useFetchRecordsOfMine } from "@/shared/hooks/record/useFetchRecordsOfMine";
 import { useFetchRecord } from "../hooks/useFetchRecord";
 
 export default function RecordDetail(): JSX.Element | null {

--- a/src/components/features/record/update/hooks/useRecordUpdateInit.ts
+++ b/src/components/features/record/update/hooks/useRecordUpdateInit.ts
@@ -16,8 +16,14 @@ export const useRecordUpdateInit = (
   const { data, loading, error } = useFetchRecord(boardId);
   const record = data?.fetchBoard;
 
+  const initializedRef = useRef<string | null>(null);
+
   useEffect(() => {
     if (!record) return;
+    if (!boardId) return;
+
+    if (initializedRef.current === boardId) return;
+    initializedRef.current = boardId;
 
     const meta = parseRecordMetaBlock(record.contents);
     const contents = stripMetaFromContents(record.contents);
@@ -33,15 +39,19 @@ export const useRecordUpdateInit = (
         "",
       roadAddress: record.boardAddress?.address ?? "",
       jibunAddress: record.boardAddress?.address ?? "",
-      x: meta?.x ?? "",
-      y: meta?.y ?? "",
+      x: meta?.x ?? undefined,
+      y: meta?.y ?? undefined,
       contents,
       imageFiles: [],
       images: (record.images ?? []).filter((v): v is string => !!v?.trim()),
     });
 
     onRecordLoaded?.();
-  }, [record]);
+  }, [boardId, record, form, onRecordLoaded]);
+
+  useEffect(() => {
+    initializedRef.current = null;
+  }, [boardId]);
 
   return {
     record,

--- a/src/components/features/record/update/ui/RecordUpdateScreen.tsx
+++ b/src/components/features/record/update/ui/RecordUpdateScreen.tsx
@@ -26,7 +26,7 @@ export default function RecordUpdateScreen() {
       DRAFT_KEY.record.update(recordId ?? "")
     );
 
-  const { success } = useToast();
+  const { success, error } = useToast();
 
   const { openConfirmPreset } = useConfirmPreset();
   const { form, ...editorProps } = useRecordEditorForm((values) => {
@@ -34,18 +34,26 @@ export default function RecordUpdateScreen() {
     return onSubmitValid(values, recordId!);
   });
 
-  const { loading, error } = useRecordUpdateInit(recordId, form, () => {
-    const draft = loadDraft();
-    if (!draft) return;
+  const { loading, error: initError } = useRecordUpdateInit(
+    recordId,
+    form,
+    () => {
+      const draft = loadDraft();
+      if (!draft) return;
+      if (initError) {
+        error("기록을 불러오는 중 에러가 발생했어요");
+        return;
+      }
 
-    openConfirmPreset("loadDraft", {
-      onConfirm: () => {
-        form.reset({ ...draft });
-        success("임시 저장된 내용을 불러왔어요.");
-      },
-      onCancel: () => clearDraft(),
-    });
-  });
+      openConfirmPreset("loadDraft", {
+        onConfirm: () => {
+          form.reset({ ...draft });
+          success("임시 저장된 내용을 불러왔어요.");
+        },
+        onCancel: () => clearDraft(),
+      });
+    }
+  );
 
   const onTempSave = () => {
     const values = form.getValues();
@@ -57,7 +65,7 @@ export default function RecordUpdateScreen() {
   const isDirty = form.formState.isDirty;
 
   if (!recordId) return <div>잘못된 접근입니다.</div>;
-
+  if (loading) return <div>로딩 중..</div>;
   return (
     <div className="min-h-screen bg-background ">
       <BackButton fallbackHref="/records" label="뒤로가기" />

--- a/src/components/features/record/write/ui/RecordWriteScreen.tsx
+++ b/src/components/features/record/write/ui/RecordWriteScreen.tsx
@@ -26,13 +26,13 @@ export default function RecordWriteScreen() {
 
   const { openConfirmPreset } = useConfirmPreset();
 
+  const { form, ...editorProps } = useRecordEditorForm(onSubmitValid);
+
   const onTempSave = () => {
     const values = form.getValues();
     saveDraft(values);
     success("텍스트 내용이 임시저장됐어요.\n(이미지는 저장되지 않아요😢)");
   };
-
-  const { form, ...editorProps } = useRecordEditorForm(onSubmitValid);
 
   const disabled = isBusy || form.formState.isSubmitting;
   const isDirty = form.formState.isDirty;
@@ -50,7 +50,7 @@ export default function RecordWriteScreen() {
         clearDraft();
       },
     });
-  }, []);
+  }, [loadDraft, openConfirmPreset, form, success, clearDraft]);
 
   return (
     <div className="min-h-screen bg-background ">

--- a/src/components/ui/logo/Logo.stories.tsx
+++ b/src/components/ui/logo/Logo.stories.tsx
@@ -19,4 +19,4 @@ const meta: Meta<typeof Logo> = {
 export default meta;
 type Story = StoryObj<typeof Logo>;
 
-export const defaultLogo: Story = {};
+export const DefaultLogo: Story = {};

--- a/src/shared/hooks/auth/useAuthInitialize.ts
+++ b/src/shared/hooks/auth/useAuthInitialize.ts
@@ -56,7 +56,7 @@ export function useAuthInitialize() {
           setUser(null);
         }
       } catch (e) {
-        // console.error("Failed to initialize auth", e);
+        console.log("Failed to initialize auth", e);
 
         if (cancelled) return;
         setAccessToken("");

--- a/src/shared/stores/atomWithDevCache.ts
+++ b/src/shared/stores/atomWithDevCache.ts
@@ -2,13 +2,20 @@ import { atom, type AtomOptions, type RecoilState } from "recoil";
 
 const STORE_KEY = "__recoil_atom_cache__";
 
+type AtomCache = Record<string, RecoilState<unknown>>;
+
+interface CustomGlobal {
+  [STORE_KEY]?: AtomCache;
+}
+
 export function atomWithDevCache<T>(options: AtomOptions<T>): RecoilState<T> {
   if (process.env.NODE_ENV === "production") return atom<T>(options);
 
-  const g = globalThis as any;
+  const g = globalThis as typeof globalThis & CustomGlobal;
   g[STORE_KEY] = g[STORE_KEY] ?? {};
-  if (g[STORE_KEY][options.key]) return g[STORE_KEY][options.key];
+  if (g[STORE_KEY][options.key])
+    return g[STORE_KEY]![options.key] as RecoilState<T>;
 
-  g[STORE_KEY][options.key] = atom<T>(options);
-  return g[STORE_KEY][options.key];
+  g[STORE_KEY]![options.key] = atom<T>(options) as RecoilState<unknown>;
+  return g[STORE_KEY]![options.key] as RecoilState<T>;
 }


### PR DESCRIPTION
eslint 에러 수정
- `src/shared/graphql/generated/types.ts`:  eslint-ignore 추가
- `PlaceSearchModal.stories.tsx`:  스토리코드 MockMode 타입 분리
- `useDeleteRecordComment.ts`:  Reference 타입 적용
- `atomWithDevCache.ts`: globalThis에 커스텀 프로퍼티를 포함한 타입 선언

RecordComments 무한스크롤 구현
- useFetchRecordComments 내부에 loadMore 함수 구현