### PR TITLE
✨[Feat] CORS 문제 해결을 위한 graphQL 프록시 구현

### DIFF
--- a/pages/api/graphql.ts
+++ b/pages/api/graphql.ts
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import http from "http";
+import https from "https";
+
+export const config = { api: { bodyParser: false } };
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const target = process.env.NEXT_PUBLIC_GRAPHQL_URI;
+  if (!target) {
+    res.status(500).json({ message: "NEXT_PUBLIC_GRAPHQL_URI is not set" });
+    return;
+  }
+
+  const url = new URL(target);
+  const transport = url.protocol === "https:" ? https : http;
+
+  const proxyReq = transport.request(
+    {
+      hostname: url.hostname,
+      port: url.port || (url.protocol === "https:" ? 443 : 80),
+      path: url.pathname,
+      method: req.method,
+      headers: {
+        ...req.headers,
+        host: url.host,
+        ...(req.headers.authorization
+          ? { authorization: req.headers.authorization }
+          : {}),
+        ...(req.headers.cookie ? { cookie: req.headers.cookie } : {}),
+      },
+    },
+    (proxyRes) => {
+      res.writeHead(proxyRes.statusCode ?? 200, {
+        ...proxyRes.headers,
+        // Explicitly forward Set-Cookie so the browser receives refresh token cookies
+        ...(proxyRes.headers["set-cookie"]
+          ? { "set-cookie": proxyRes.headers["set-cookie"] }
+          : {}),
+      });
+      proxyRes.pipe(res);
+    }
+  );
+
+  proxyReq.on("error", (err) => {
+    console.error("[graphql proxy] upstream error", err);
+    if (!res.headersSent) {
+      res.status(502).json({ message: "Bad Gateway" });
+    }
+  });
+
+  req.pipe(proxyReq);
+}

--- a/src/lib/apollo/ApolloSetting.tsx
+++ b/src/lib/apollo/ApolloSetting.tsx
@@ -110,7 +110,7 @@ export default function ApolloSetting({ children }: IApolloSettingProps) {
   const uploadLink = useMemo(
     () =>
       createUploadLink({
-        uri: process.env.NEXT_PUBLIC_GRAPHQL_URI,
+        uri: "/api/graphql",
         credentials: "include",
       }),
     []

--- a/src/lib/getAccessToken.ts
+++ b/src/lib/getAccessToken.ts
@@ -22,10 +22,13 @@ export function getAccessToken(): Promise<string | null> {
   if (refreshingPromise) return refreshingPromise;
 
   refreshingPromise = (async () => {
-    // ✅ 쿠키 기반 refresh는 "브라우저"에서만 의미가 있음
-    if (typeof window === "undefined") return null;
+    // Browser: route through the Next.js proxy to avoid CORS.
+    // SSR: call the backend directly (no browser cookie jar, proxy not available).
+    const uri =
+      typeof window !== "undefined"
+        ? "/api/graphql"
+        : process.env.NEXT_PUBLIC_GRAPHQL_URI;
 
-    const uri = process.env.NEXT_PUBLIC_GRAPHQL_URI;
     if (!uri) {
       console.error("NEXT_PUBLIC_GRAPHQL_URI is not set");
       return null;


### PR DESCRIPTION
## Proxy 구현
- `pages/api/graphql.ts` 추가: Next.js API Route로 백엔드 GraphQL 요청을 프록시
- `ApolloSetting.tsx`: uploadLink.uri를 `/api/graphql`로 변경
- `getAccessToken.ts`: 브라우저는 `/api/graphql`, SSR은 NEXT_PUBLIC_GRAPHQL_URI 직접 사용

## 세부사항
- bodyParser: false 설정으로 multipart 파일 업로드 스트림 그대로 통과
- Authorization, Cookie 헤더 upstream 전달
- Set-Cookie 응답 헤더 브라우저로 전달 (refresh token 쿠키 유지)

## Test plan
- [ ] 로그인 / 로그아웃 정상 동작 확인
- [ ] accessToken 만료 시 자동 refresh 확인
- [ ] 파일(이미지) 업로드 정상 동작 확인
- [ ] SSR 페이지에서 GraphQL 요청 정상 동작 확인
