### PR TITLE
🐛[Fix] proxy set-cookie 에러 수정

### DIFF
--- a/pages/api/graphql.ts
+++ b/pages/api/graphql.ts
@@ -23,20 +23,52 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
       headers: {
         ...req.headers,
         host: url.host,
-        ...(req.headers.authorization
-          ? { authorization: req.headers.authorization }
-          : {}),
-        ...(req.headers.cookie ? { cookie: req.headers.cookie } : {}),
       },
     },
     (proxyRes) => {
-      res.writeHead(proxyRes.statusCode ?? 200, {
-        ...proxyRes.headers,
-        // Explicitly forward Set-Cookie so the browser receives refresh token cookies
-        ...(proxyRes.headers["set-cookie"]
-          ? { "set-cookie": proxyRes.headers["set-cookie"] }
-          : {}),
-      });
+      // ✅ CORS 헤더 제거 (브라우저 혼동 방지)
+      const filteredHeaders: Record<string, string | string[]> = {};
+      for (const [key, value] of Object.entries(proxyRes.headers)) {
+        if (key.toLowerCase().startsWith("access-control-")) continue;
+        if (value !== undefined)
+          filteredHeaders[key] = value as string | string[];
+      }
+
+      // ✅ Set-Cookie 수정
+      const setCookies = proxyRes.headers["set-cookie"];
+      if (setCookies) {
+        const arr = Array.isArray(setCookies) ? setCookies : [setCookies];
+
+        filteredHeaders["set-cookie"] = arr.map((cookie) => {
+          let c = cookie;
+
+          // 1) Domain 제거 (서비스 도메인에 저장 가능하게)
+          c = c.replace(/;\s*domain=[^;]+/gi, "");
+
+          // 2) SameSite 제거 후 Lax로 통일
+          c = c.replace(/;\s*SameSite=\w+/gi, "");
+
+          // 3) 중복 세미콜론 정리 (Domain, SameSite 제거 후 발생할 수 있는 ;;)
+          c = c.replace(/;;+/g, ";");
+
+          // 4) SameSite=Lax 추가
+          c += "; SameSite=Lax";
+
+          // 5) Path=/ 없으면 추가
+          if (!/;\s*Path=/i.test(c)) {
+            c += "; Path=/";
+          }
+
+          // 6) https면 Secure 없으면 추가
+          if (url.protocol === "https:" && !/;\s*Secure/i.test(c)) {
+            c += "; Secure";
+          }
+
+          return c;
+        });
+      }
+
+      res.writeHead(proxyRes.statusCode ?? 200, filteredHeaders);
       proxyRes.pipe(res);
     }
   );

--- a/src/lib/getAccessToken.ts
+++ b/src/lib/getAccessToken.ts
@@ -26,7 +26,7 @@ export function getAccessToken(): Promise<string | null> {
     // SSR: call the backend directly (no browser cookie jar, proxy not available).
     const uri =
       typeof window !== "undefined"
-        ? "/api/graphql"
+        ? `${window.location.origin}/api/graphql`
         : process.env.NEXT_PUBLIC_GRAPHQL_URI;
 
     if (!uri) {


### PR DESCRIPTION
## 📌 작업 내용

### 🐛 버그 수정

**1. getAccessToken.ts — Invalid URL 에러 수정**

graphql-request가 내부적으로 `new URL(uri)` 호출 시
`/api/graphql` 상대경로는 허용 안 돼서 에러 발생.
`window.location.origin`을 붙여 절대경로로 변경함.

- 브라우저: `window.location.origin + /api/graphql` (프록시 경유)
- SSR: `process.env.NEXT_PUBLIC_GRAPHQL_URI` (직접 호출)

**2. pages/api/graphql.ts — refreshToken 쿠키 미저장 수정**

백엔드 `Set-Cookie`에 `Domain=백엔드도메인`이 박혀있어
브라우저가 프록시 도메인에 쿠키 저장 거부.
CORS 헤더도 그대로 전달돼 브라우저가 응답 자체를 거부하는 문제도 있었음.

변경 내용:
- `access-control-*` 헤더 전부 제거
- `Domain` 제거 → 프록시 도메인에 저장 가능하게
- `SameSite=Lax`로 통일
- `Path=/` 없으면 추가
- `Secure` 없으면 추가 (https 환경)
- 중복 세미콜론 정리

---

## 💡 원인 요약
수정 전
브라우저 → 프록시 → 백엔드
← Set-Cookie에 Domain=백엔드도메인 포함
← 브라우저가 프록시 도메인에 저장 거부
← refreshToken 없음 → 로그인 유지 안 됨

수정 후
브라우저 → 프록시 → 백엔드
← Domain 제거 + SameSite=Lax + Path=/ + Secure
← 쿠키 정상 저장 ✅ → 로그인 유지 ✅

