### PR TITLE
✅ [Test] E2E 테스트 구축 & 임시저장 버그 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ next-env.d.ts
 
 *storybook.log
 storybook-static
+
+# playwright
+/playwright-report
+/test-results

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,6 +10,16 @@ const config: StorybookConfig = {
   ],
   framework: { name: "@storybook/nextjs-vite", options: {} },
   staticDirs: ["../public"],
+  viteFinal: (config) => ({
+    ...config,
+    resolve: {
+      ...config.resolve,
+      // Ensure a single React + Recoil instance across all Storybook bundles.
+      // Without this, Recoil's cached ESM bundle uses a different React copy
+      // and crashes when accessing __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.
+      dedupe: ["react", "react-dom", "recoil"],
+    },
+  }),
 };
 
 export default config;

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const EMAIL = process.env.E2E_TEST_EMAIL ?? "";
+const PASSWORD = process.env.E2E_TEST_PASSWORD ?? "";
+
+// Desktop Chrome viewport(1280px)는 Tailwind lg(1024px) 이상이므로 SideNav가 렌더됨
+async function login(page: Page) {
+  console.log(EMAIL, PASSWORD);
+  await page.goto("/login");
+  // FormLabel(htmlFor) + input(id) 매핑 기반 셀렉터
+  await page.getByTestId("login-email").fill(EMAIL);
+  await page.getByTestId("login-password").fill(PASSWORD);
+
+  await expect(page.getByTestId("login-email")).toHaveValue(EMAIL);
+  await expect(page.getByTestId("login-password")).toHaveValue(PASSWORD);
+
+  await expect(page.getByTestId("login-submit")).toBeEnabled();
+  await page.getByTestId("login-submit").click();
+  await page.waitForURL("/");
+}
+
+test.describe("인증 (E2E)", () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  test("로그인 성공 시 refreshToken 쿠키가 저장됨", async ({
+    page,
+    context,
+  }) => {
+    await login(page);
+
+    const cookies = await context.cookies();
+    const refreshToken = cookies.find((c) => c.name === "refreshToken");
+    expect(refreshToken).toBeDefined();
+  });
+
+  test("새로고침 후 로그인이 유지됨", async ({ page }) => {
+    await login(page);
+
+    await page.reload();
+
+    // 데스크탑 SideNav에 로그아웃 버튼이 보이면 로그인 상태 유지됨
+    await expect(page.getByRole("button", { name: "로그아웃" })).toBeVisible();
+  });
+
+  test("로그아웃 후 쿠키가 삭제됨", async ({ page, context }) => {
+    await login(page);
+
+    // SideNav 로그아웃 버튼 클릭 → 확인 모달의 "로그아웃" 버튼 클릭
+    await page.getByRole("button", { name: "로그아웃" }).click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "로그아웃" })
+      .click();
+
+    await page.waitForResponse(
+      (res) => res.url().includes("/api/logout") && res.ok(),
+    );
+
+    const cookies = await context.cookies();
+    const refreshToken = cookies.find((c) => c.name === "refreshToken");
+    expect(refreshToken).toBeUndefined();
+  });
+});

--- a/e2e/draft.spec.ts
+++ b/e2e/draft.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const EMAIL = process.env.E2E_TEST_EMAIL ?? "";
+const PASSWORD = process.env.E2E_TEST_PASSWORD ?? "";
+const DRAFT_KEY = "record:draft:write";
+
+async function login(page: Page) {
+  await page.goto("/login");
+  await page.getByTestId("login-email").fill(EMAIL);
+  await page.getByTestId("login-password").fill(PASSWORD);
+  await page.getByTestId("login-submit").click();
+  await page.waitForURL("/");
+}
+
+async function clearDraft(page: Page) {
+  await page.evaluate((key) => localStorage.removeItem(key), DRAFT_KEY);
+}
+
+async function fillForm(page: Page, showName: string, contents: string) {
+  await page.locator('input[name="showName"]').fill(showName);
+  await page.locator(".ProseMirror").click();
+  await page.locator(".ProseMirror").pressSequentially(contents);
+}
+
+async function saveDraft(page: Page) {
+  await page.getByRole("button", { name: "임시 저장" }).click();
+  await expect(page.getByText("텍스트 내용이 임시저장됐어요")).toBeVisible();
+}
+
+test.describe("임시저장 (E2E)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await clearDraft(page);
+  });
+
+  test("임시저장 버튼 클릭 시 토스트 메시지가 표시됨", async ({ page }) => {
+    await page.goto("/records/new");
+    await fillForm(page, "서울재즈페스티벌 2026", "정말 멋진 공연이었습니다.");
+
+    await page.getByRole("button", { name: "임시 저장" }).click();
+
+    await expect(page.getByText("텍스트 내용이 임시저장됐어요")).toBeVisible();
+  });
+
+  test("임시저장 후 재진입 시 복구 모달이 표시됨", async ({ page }) => {
+    await page.goto("/records/new");
+    await fillForm(page, "서울재즈페스티벌 2026", "정말 멋진 공연이었습니다.");
+    await saveDraft(page);
+
+    await page.goto("/records");
+    await page.goto("/records/new");
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByText("임시 저장된 내용이 있어요")).toBeVisible();
+  });
+
+  test("복구 확인 시 입력했던 내용이 폼에 채워짐", async ({ page }) => {
+    const showName = "서울재즈페스티벌 2026";
+    const contents = "정말 멋진 공연이었습니다.";
+
+    await page.goto("/records/new");
+    await fillForm(page, showName, contents);
+    await saveDraft(page);
+
+    await page.goto("/records");
+    await page.goto("/records/new");
+
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "이어서 작성" })
+      .click();
+
+    await expect(page.locator('input[name="showName"]')).toHaveValue(showName);
+    await expect(page.locator(".ProseMirror")).toContainText(contents);
+  });
+
+  test("복구 후 내용 수정해도 복구 모달이 다시 뜨지 않음", async ({
+    page,
+  }) => {
+    await page.goto("/records/new");
+    await fillForm(page, "서울재즈페스티벌 2026", "정말 멋진 공연이었습니다.");
+    await saveDraft(page);
+
+    await page.goto("/records");
+    await page.goto("/records/new");
+
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "이어서 작성" })
+      .click();
+
+    // form.reset() 후 리렌더링 시 모달이 다시 열리는 회귀 버그 방지
+    await page.locator('input[name="showName"]').fill("수정된 공연명");
+
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+
+  test("복구 취소 시 폼이 비어있음", async ({ page }) => {
+    await page.goto("/records/new");
+    await fillForm(page, "서울재즈페스티벌 2026", "정말 멋진 공연이었습니다.");
+    await saveDraft(page);
+
+    await page.goto("/records");
+    await page.goto("/records/new");
+
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "새로 작성" })
+      .click();
+
+    await expect(page.locator('input[name="showName"]')).toHaveValue("");
+    await expect(page.locator(".ProseMirror")).not.toContainText(
+      "정말 멋진 공연이었습니다.",
+    );
+  });
+
+  test("복구 취소 후 재진입 시 모달이 뜨지 않음", async ({ page }) => {
+    await page.goto("/records/new");
+    await fillForm(page, "서울재즈페스티벌 2026", "정말 멋진 공연이었습니다.");
+    await saveDraft(page);
+
+    await page.goto("/records");
+    await page.goto("/records/new");
+
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "새로 작성" })
+      .click();
+
+    // 취소 시 clearDraft 동작 확인 - 재진입해도 모달 미표시
+    await page.goto("/records");
+    await page.goto("/records/new");
+
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+
+  test("임시저장 없이 진입 시 모달이 뜨지 않음", async ({ page }) => {
+    // beforeEach에서 localStorage 초기화 완료 상태
+    await page.goto("/records/new");
+
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+});

--- a/e2e/record.spec.ts
+++ b/e2e/record.spec.ts
@@ -1,0 +1,206 @@
+import { test, expect, type Cookie, type Page } from "@playwright/test";
+
+const EMAIL = process.env.E2E_TEST_EMAIL ?? "";
+const PASSWORD = process.env.E2E_TEST_PASSWORD ?? "";
+
+// ─── 헬퍼 ──────────────────────────────────────────────────────────────────
+
+async function login(page: Page) {
+  await page.goto("/login");
+  await page.getByTestId("login-email").fill(EMAIL);
+  await page.getByTestId("login-password").fill(PASSWORD);
+  await page.getByTestId("login-submit").click();
+  await page.waitForURL("/");
+}
+
+type RecordData = {
+  showName: string;
+  artistName: string;
+  showDate: string;
+  contents: string;
+};
+
+async function fillRecordForm(page: Page, data: RecordData) {
+  await page.locator('input[name="showName"]').fill(data.showName);
+  await page.locator('input[name="artistName"]').fill(data.artistName);
+  await page.locator('input[name="showDate"]').fill(data.showDate);
+  await page.locator(".ProseMirror").click();
+  await page.locator(".ProseMirror").pressSequentially(data.contents);
+}
+
+/** 기록을 작성하고 생성된 recordId를 반환한다. */
+async function createRecord(page: Page, data: RecordData): Promise<string> {
+  await page.goto("/records/new");
+  await fillRecordForm(page, data);
+  await page.getByRole("button", { name: "기록 저장" }).click();
+  // /records/new, /records/update/* 가 아닌 /records/{id} 를 기다림
+  await page.waitForURL(/\/records\/(?!new$|update\/)[^/]+$/);
+  return page.url().split("/").pop()!;
+}
+
+/** 상세 페이지의 WriterMenu → 삭제하기 → 확인 모달로 기록을 삭제한다. */
+async function deleteRecord(page: Page, recordId: string) {
+  await page.goto(`/records/${recordId}`);
+  await page.locator("button:has(.lucide-ellipsis-vertical)").click();
+  await page.getByRole("button", { name: "삭제하기" }).click();
+  await page.getByRole("dialog").getByRole("button", { name: "삭제" }).click();
+  await page.waitForURL(/\/records$/);
+}
+
+// ─── 테스트 ────────────────────────────────────────────────────────────────
+
+test.describe.serial("기록 (E2E)", () => {
+  // test.use({ storageState: path })는 beforeAll보다 먼저 파일을 읽으므로
+  // 첫 실행 시 ENOENT가 발생한다 → 파일 없이 addCookies로 인메모리 적용
+  let authCookies: Cookie[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await login(page);
+    const state = await context.storageState();
+    authCookies = state.cookies;
+    await context.close();
+  });
+
+  test.beforeEach(async ({ context }) => {
+    await context.addCookies(authCookies);
+  });
+
+  // 각 테스트에서 생성한 기록 ID — afterEach에서 정리
+  let createdRecordId = "";
+
+  test.afterEach(async ({ page }, testInfo) => {
+    if (!createdRecordId) return;
+
+    try {
+      await deleteRecord(page, createdRecordId);
+    } catch (e) {
+      // cleanup 실패는 테스트 결과를 덮어쓰지 않게 로그만 남김
+      testInfo.attach("cleanup-error", {
+        body: String(e),
+        contentType: "text/plain",
+      });
+    } finally {
+      createdRecordId = "";
+    }
+  });
+
+  // ── 1. 작성 ──────────────────────────────────────────────────────────────
+
+  test("기록 작성 후 목록에 표시됨", async ({ page }) => {
+    const data: RecordData = {
+      showName: "E2E 테스트 공연",
+      artistName: "E2E 아티스트",
+      showDate: "2026-01-01",
+      contents: "E2E 자동 테스트 후기입니다.",
+    };
+
+    createdRecordId = await createRecord(page, data);
+
+    await page.goto("/records");
+
+    // RecordCard > RecordCardContent 가 board.title 을 <h3> 으로 렌더링
+    const expectedTitle = `${data.showName} - ${data.artistName}`;
+    await expect(
+      page
+        .getByRole("heading", { level: 3 })
+        .filter({ hasText: expectedTitle })
+        .first(),
+    ).toBeVisible();
+  });
+
+  // ── 2. 유효성 ────────────────────────────────────────────────────────────
+
+  test("필수 항목 미입력 시 유효성 에러 표시됨", async ({ page }) => {
+    await page.goto("/records/new");
+
+    await page.getByRole("button", { name: "기록 저장" }).click();
+
+    // 폼이 제출되지 않아 URL 유지
+    await expect(page).toHaveURL("/records/new");
+
+    // TextField 에러: border-red-500 클래스 추가
+    await expect(page.locator('input[name="showName"]')).toHaveClass(
+      /border-red-500/,
+    );
+    await expect(page.locator('input[name="artistName"]')).toHaveClass(
+      /border-red-500/,
+    );
+    await expect(page.locator('input[name="showDate"]')).toHaveClass(
+      /border-red-500/,
+    );
+
+    // TiptapEditor 에러: 에러 문구 직접 렌더링
+    await expect(page.getByText("후기를 입력해주세요.")).toBeVisible();
+  });
+
+  // ── 3. 수정 ──────────────────────────────────────────────────────────────
+
+  test("기록 수정 후 내용이 변경됨", async ({ page }) => {
+    const initial: RecordData = {
+      showName: "E2E 수정 전 공연",
+      artistName: "E2E 아티스트",
+      showDate: "2026-01-01",
+      contents: "수정 전 후기입니다.",
+    };
+
+    createdRecordId = await createRecord(page, initial);
+
+    // 상세 페이지 → WriterMenu → 수정하기
+    await page.locator("button:has(.lucide-ellipsis-vertical)").click();
+    await page.getByRole("button", { name: "수정하기" }).click();
+    await page.waitForURL(/\/records\/update\//);
+
+    // 공연명 수정
+    const updatedShowName = "E2E 수정 후 공연";
+    await page.locator('input[name="showName"]').fill(updatedShowName);
+
+    // 후기 수정: 전체 선택 후 교체
+    await page.locator(".ProseMirror").click();
+    await page.keyboard.press("Control+A");
+    await page
+      .locator(".ProseMirror")
+      .pressSequentially("수정된 후기 내용입니다.");
+
+    // 수정하기 제출 (RecordUpdateActions의 type="submit" 버튼)
+    await page.getByRole("button", { name: "수정하기" }).click();
+    await page.waitForURL(/\/records\/(?!update\/)[^/]+$/);
+
+    const expectedTitle = `${updatedShowName} - ${initial.artistName}`;
+    await expect(
+      page.getByRole("heading", { level: 1, name: expectedTitle }),
+    ).toBeVisible();
+  });
+
+  // ── 4. 삭제 ──────────────────────────────────────────────────────────────
+
+  test("기록 삭제 후 목록에서 사라짐", async ({ page }) => {
+    const data: RecordData = {
+      showName: "E2E 삭제 공연",
+      artistName: "E2E 아티스트",
+      showDate: "2026-01-01",
+      contents: "삭제될 후기입니다.",
+    };
+
+    createdRecordId = await createRecord(page, data);
+
+    const expectedTitle = `${data.showName} - ${data.artistName}`;
+
+    // 상세 페이지 → WriterMenu → 삭제하기 → 모달 확인
+    await page.locator("button:has(.lucide-ellipsis-vertical)").click();
+    await page.getByRole("button", { name: "삭제하기" }).click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "삭제" })
+      .click();
+    await page.waitForURL(/\/records$/);
+
+    await expect(
+      page.getByRole("heading", { name: expectedTitle }),
+    ).not.toBeVisible();
+
+    // afterEach 재삭제 방지
+    createdRecordId = "";
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test:unit": "vitest --project unit",
     "test:sb": "vitest --project storybook",
     "test:unit:run": "vitest --project unit run",
-    "test:sb:run": "vitest --project storybook run"
+    "test:sb:run": "vitest --project storybook run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@apollo/client": "^3.7.1",
@@ -47,6 +49,7 @@
     "@graphql-codegen/introspection": "^5.0.0",
     "@graphql-codegen/typescript": "^5.0.7",
     "@graphql-codegen/typescript-operations": "^5.0.7",
+    "@playwright/test": "^1.59.1",
     "@storybook/addon-a11y": "^10.2.6",
     "@storybook/addon-docs": "^10.2.6",
     "@storybook/addon-vitest": "^10.2.6",
@@ -62,11 +65,12 @@
     "@types/react-dom": "^19",
     "@vitest/browser-playwright": "^4.0.18",
     "@vitest/coverage-v8": "^4.0.18",
+    "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "eslint-plugin-storybook": "^10.2.6",
     "jsdom": "^28.1.0",
-    "playwright": "^1.58.1",
+    "playwright": "^1.59.1",
     "storybook": "^10.2.6",
     "tailwindcss": "^4",
     "typescript": "^5",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@storybook/addon-vitest": "^10.2.6",
     "@storybook/nextjs-vite": "^10.2.6",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/pages/api/graphql.ts
+++ b/pages/api/graphql.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import http from "http";
 import https from "https";
+import { transformSetCookies } from "@/lib/proxy/transformSetCookies";
 
 export const config = { api: { bodyParser: false } };
 
@@ -34,38 +35,10 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
           filteredHeaders[key] = value as string | string[];
       }
 
-      // ✅ Set-Cookie 수정
       const setCookies = proxyRes.headers["set-cookie"];
       if (setCookies) {
         const arr = Array.isArray(setCookies) ? setCookies : [setCookies];
-
-        filteredHeaders["set-cookie"] = arr.map((cookie) => {
-          let c = cookie;
-
-          // 1) Domain 제거 (서비스 도메인에 저장 가능하게)
-          c = c.replace(/;\s*domain=[^;]+/gi, "");
-
-          // 2) SameSite 제거 후 Lax로 통일
-          c = c.replace(/;\s*SameSite=\w+/gi, "");
-
-          // 3) 중복 세미콜론 정리 (Domain, SameSite 제거 후 발생할 수 있는 ;;)
-          c = c.replace(/;;+/g, ";");
-
-          // 4) SameSite=Lax 추가
-          c += "; SameSite=Lax";
-
-          // 5) Path=/ 없으면 추가
-          if (!/;\s*Path=/i.test(c)) {
-            c += "; Path=/";
-          }
-
-          // 6) https면 Secure 없으면 추가
-          if (url.protocol === "https:" && !/;\s*Secure/i.test(c)) {
-            c += "; Secure";
-          }
-
-          return c;
-        });
+        filteredHeaders["set-cookie"] = transformSetCookies(arr, url.protocol);
       }
 
       res.writeHead(proxyRes.statusCode ?? 200, filteredHeaders);

--- a/pages/api/logout.ts
+++ b/pages/api/logout.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+function isHttps(req: NextApiRequest) {
+  const xfProto = req.headers["x-forwarded-proto"];
+  return typeof xfProto === "string" && xfProto.includes("https");
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const secure = isHttps(req) ? "; Secure" : "";
+
+  const base = `Path=/; HttpOnly; SameSite=Lax; Max-Age=0${secure}`;
+
+  res.setHeader("Set-Cookie", [
+    `refreshToken=; ${base}`,
+    `refresh-token=; ${base}`,
+  ]);
+
+  return res.status(200).json({ ok: true });
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+
+dotenv.config({ path: ".env.e2e" });
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/src/components/commons/comment/commentItem/CommentItem.stories.tsx
+++ b/src/components/commons/comment/commentItem/CommentItem.stories.tsx
@@ -1,6 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import CommentItem from "./CommentItem";
 import type { IBoardComment } from "@/shared/graphql/generated/types";
+import { CommentActionsProvider } from "../context/CommentActionsContext";
+
+const mockActions = {
+  canEdit: () => false,
+  onSave: async () => {},
+  onRequestDelete: () => {},
+};
 
 const meta: Meta<typeof CommentItem> = {
   title: "commons/comment/CommentItem",
@@ -8,9 +15,11 @@ const meta: Meta<typeof CommentItem> = {
   parameters: { layout: "padded" },
   decorators: [
     (Story) => (
-      <div className="max-w-2xl p-6 bg-background">
-        <Story />
-      </div>
+      <CommentActionsProvider value={mockActions}>
+        <div className="max-w-2xl p-6 bg-background">
+          <Story />
+        </div>
+      </CommentActionsProvider>
     ),
   ],
 };

--- a/src/components/commons/layout/SideNav/ProfileEntry/ProfileEntry.stories.tsx
+++ b/src/components/commons/layout/SideNav/ProfileEntry/ProfileEntry.stories.tsx
@@ -1,16 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import type { IUser } from "@/shared/graphql/generated/types";
 import ProfileEntry from "./ProfileEntry";
-// import { vi } from "vitest";
-
-// // ✅ UI 확인용 Avatar mock
-// vi.mock("@/components/commons/avatar/Avatar", () => ({
-//   default: () => (
-//     <div className="h-9 w-9 rounded-full bg-white/20 border border-white/30 text-white font-bold flex items-center justify-center">
-//       A
-//     </div>
-//   ),
-// }));
 
 const baseUser: IUser = {
   __typename: "User",
@@ -41,12 +31,11 @@ export default meta;
 type Story = StoryObj<typeof ProfileEntry>;
 
 export const LoggedOut: Story = {
-  args: { user: baseUser, variant: "loggedOut" },
+  args: { user: null },
 };
 
 export const LoggedIn_LongName: Story = {
   args: {
     user: { ...baseUser, name: "아주아주아주긴이름테스트아주아주아주긴이름" },
-    variant: "loggedIn",
   },
 };

--- a/src/components/commons/layout/SideNav/ProfileEntry/ProfileEntry.tsx
+++ b/src/components/commons/layout/SideNav/ProfileEntry/ProfileEntry.tsx
@@ -3,11 +3,13 @@ import Avatar from "@/components/ui/avatar/Avatar";
 import { ChevronRight } from "lucide-react";
 import { JSX } from "react";
 import { Button } from "@/components/ui/button/Button";
-import { useRecoilValue } from "recoil";
-import { loggedInUserState } from "@/shared/stores";
+import type { LoggedInUser } from "@/shared/stores";
 
-export default function ProfileEntry(): JSX.Element {
-  const me = useRecoilValue(loggedInUserState);
+interface ProfileEntryProps {
+  user?: LoggedInUser;
+}
+
+export default function ProfileEntry({ user: me = null }: ProfileEntryProps): JSX.Element {
   const isLoggedIn = !!me?._id;
 
   const { onClickNavigation } = useNavigation();

--- a/src/components/commons/layout/SideNav/SideNav.tsx
+++ b/src/components/commons/layout/SideNav/SideNav.tsx
@@ -48,7 +48,7 @@ export default function SideNav() {
       <div className="p-6 border-b border-border">
         <Logo size="lg" showSubtitle />
       </div>
-      <ProfileEntry />
+      <ProfileEntry user={me} />
       <nav className="flex flex-col overflow-y-auto p-4 space-y-2">
         <Button
           variant="outline"

--- a/src/components/features/auth/login/loginForm/LoginForm.tsx
+++ b/src/components/features/auth/login/loginForm/LoginForm.tsx
@@ -48,6 +48,7 @@ export default function LoginForm({ onSubmit }: LoginFormProps) {
         </FormLabel>
         <TextField
           name="email"
+          testId="login-email"
           type="email"
           autoComplete="email"
           placeholder="example@atfeelog.com"
@@ -63,6 +64,7 @@ export default function LoginForm({ onSubmit }: LoginFormProps) {
         </FormLabel>
         <PasswordField
           id="password"
+          testId="login-password"
           name="password"
           register={register}
           watch={watch}
@@ -74,6 +76,7 @@ export default function LoginForm({ onSubmit }: LoginFormProps) {
 
       <Button
         type="submit"
+        data-testid="login-submit"
         disabled={!isValid || isSubmitting}
         size={"lg"}
         className="w-full font-semibold mt-3"

--- a/src/components/features/record/detail/recordDetailContent/RecordDetailContent.stories.tsx
+++ b/src/components/features/record/detail/recordDetailContent/RecordDetailContent.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import type { IBoard } from "@/shared/graphql/generated/types";
+import { MockedProvider } from "@apollo/client/testing";
+import { RecoilRoot } from "recoil";
+import { ToastProvider } from "@/components/commons/toast/ToastProvider";
 import RecordDetailContent from "./RecordDetailContent";
 
 const baseRecord = {
@@ -36,11 +39,17 @@ const meta: Meta<typeof RecordDetailContent> = {
   parameters: { layout: "centered" },
   decorators: [
     (Story) => (
-      <div className="min-h-screen w-full bg-background p-8 flex justify-center">
-        <div className="w-full max-w-[720px]">
-          <Story />
-        </div>
-      </div>
+      <MockedProvider mocks={[]} addTypename={false}>
+        <RecoilRoot>
+          <ToastProvider>
+            <div className="min-h-screen w-full bg-background p-8 flex justify-center">
+              <div className="w-full max-w-[720px]">
+                <Story />
+              </div>
+            </div>
+          </ToastProvider>
+        </RecoilRoot>
+      </MockedProvider>
     ),
   ],
 };

--- a/src/components/ui/form/PasswordField.tsx
+++ b/src/components/ui/form/PasswordField.tsx
@@ -7,6 +7,7 @@ import TextField from "./TextField";
 
 export function PasswordField<TFieldValues extends FieldValues>({
   id,
+  testId,
   name,
   placeholder = "8자 이상",
   autoComplete = "new-password",
@@ -23,6 +24,7 @@ export function PasswordField<TFieldValues extends FieldValues>({
   return (
     <TextField<TFieldValues>
       {...props}
+      testId={testId}
       id={id}
       type={show ? "text" : "password"}
       name={name}

--- a/src/components/ui/form/TextField.tsx
+++ b/src/components/ui/form/TextField.tsx
@@ -5,6 +5,7 @@ import { TextFieldProps } from "./types";
 
 export function TextField<TFieldValues extends FieldValues>({
   id,
+  testId,
   name,
   type = "text",
   rightSlot,
@@ -18,6 +19,7 @@ export function TextField<TFieldValues extends FieldValues>({
   return (
     <div className="relative">
       <input
+        data-testid={testId}
         id={inputId}
         type={type}
         {...register(name)}
@@ -34,7 +36,7 @@ export function TextField<TFieldValues extends FieldValues>({
               : "border-border hover:border-primary/50"
           }
         `,
-          className
+          className,
         )}
       />
 

--- a/src/components/ui/form/types.ts
+++ b/src/components/ui/form/types.ts
@@ -25,6 +25,7 @@ export type TextFieldProps<TFieldValues extends FieldValues> = Omit<
   "name" | "value" | "defaultValue" | "onChange"
 > & {
   id?: string;
+  testId?: string;
   name: Path<TFieldValues>;
   rightSlot?: React.ReactNode;
   register: UseFormRegister<TFieldValues>;

--- a/src/lib/proxy/transformSetCookies.test.ts
+++ b/src/lib/proxy/transformSetCookies.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { transformSetCookies } from "./transformSetCookies";
+
+describe("transformSetCookies", () => {
+  it("Domain이 있으면 제거됨", () => {
+    const result = transformSetCookies(
+      ["refresh_token=abc; Domain=api.backend.com; HttpOnly"],
+      "http:"
+    );
+    expect(result[0]).not.toMatch(/domain=/i);
+  });
+
+  it("SameSite=Strict → SameSite=Lax로 변경됨", () => {
+    const result = transformSetCookies(
+      ["refresh_token=abc; SameSite=Strict; HttpOnly"],
+      "http:"
+    );
+    expect(result[0]).not.toMatch(/SameSite=Strict/i);
+    expect(result[0]).toMatch(/SameSite=Lax/);
+  });
+
+  it("SameSite=None → SameSite=Lax로 변경됨", () => {
+    const result = transformSetCookies(
+      ["refresh_token=abc; SameSite=None; Secure"],
+      "http:"
+    );
+    expect(result[0]).not.toMatch(/SameSite=None/i);
+    expect(result[0]).toMatch(/SameSite=Lax/);
+  });
+
+  it("Path=/ 없으면 추가됨", () => {
+    const result = transformSetCookies(
+      ["refresh_token=abc; HttpOnly"],
+      "http:"
+    );
+    expect(result[0]).toMatch(/Path=\//i);
+  });
+
+  it("Path=/ 이미 있으면 중복 추가되지 않음", () => {
+    const result = transformSetCookies(
+      ["refresh_token=abc; Path=/; HttpOnly"],
+      "http:"
+    );
+    const matches = result[0].match(/Path=/gi) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it("https면 Secure가 추가됨", () => {
+    const result = transformSetCookies(
+      ["refresh_token=abc; HttpOnly"],
+      "https:"
+    );
+    expect(result[0]).toMatch(/;\s*Secure/i);
+  });
+
+  it("http면 Secure가 추가되지 않음", () => {
+    const result = transformSetCookies(
+      ["refresh_token=abc; HttpOnly"],
+      "http:"
+    );
+    expect(result[0]).not.toMatch(/;\s*Secure/i);
+  });
+
+  it("중복 세미콜론이 정리됨", () => {
+    const result = transformSetCookies(["refresh_token=abc;; HttpOnly"], "http:");
+    expect(result[0]).not.toMatch(/;;/);
+  });
+
+  it("여러 쿠키를 한 번에 처리함", () => {
+    const result = transformSetCookies(
+      [
+        "access_token=tok1; Domain=api.example.com; SameSite=Strict",
+        "refresh_token=tok2; Domain=api.example.com; SameSite=None",
+      ],
+      "https:"
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).not.toMatch(/domain=/i);
+    expect(result[0]).toMatch(/SameSite=Lax/);
+    expect(result[1]).not.toMatch(/domain=/i);
+    expect(result[1]).toMatch(/SameSite=Lax/);
+  });
+});

--- a/src/lib/proxy/transformSetCookies.ts
+++ b/src/lib/proxy/transformSetCookies.ts
@@ -1,0 +1,33 @@
+/**
+ * Normalizes Set-Cookie headers forwarded from the upstream GraphQL server
+ * so they are stored and sent correctly by the browser for the Next.js origin.
+ *
+ * - Removes `Domain`    : upstream domain must not override the Next.js origin
+ * - Replaces `SameSite` : normalizes to Lax for same-site proxy requests
+ * - Adds `Path=/`       : ensures the cookie is available for all routes
+ * - Adds `Secure`       : only when the upstream uses HTTPS
+ */
+export function transformSetCookies(
+  cookies: string[],
+  targetProtocol: string
+): string[] {
+  return cookies.map((cookie) => {
+    let c = cookie;
+
+    c = c.replace(/;\s*domain=[^;]+/gi, "");
+    c = c.replace(/;\s*SameSite=\w+/gi, "");
+    c = c.replace(/;;+/g, ";");
+
+    c += "; SameSite=Lax";
+
+    if (!/;\s*Path=/i.test(c)) {
+      c += "; Path=/";
+    }
+
+    if (targetProtocol === "https:" && !/;\s*Secure/i.test(c)) {
+      c += "; Secure";
+    }
+
+    return c;
+  });
+}

--- a/src/shared/hooks/auth/useLogoutUser.ts
+++ b/src/shared/hooks/auth/useLogoutUser.ts
@@ -21,7 +21,9 @@ export default function useLogoutUser() {
       await logoutUser({
         context: { credentials: "include" },
       });
+    } catch {
     } finally {
+      await fetch("/api/logout", { method: "POST" });
       setAccessToken("");
       setUser(null);
     }

--- a/src/shared/hooks/record/useDraftStorage.test.ts
+++ b/src/shared/hooks/record/useDraftStorage.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useDraftStorage } from "./useDraftStorage";
+
+const KEY = "test-draft";
+
+type TestForm = { title: string; body: string };
+
+function makeLocalStorageMock() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      Object.keys(store).forEach((k) => delete store[k]);
+    }),
+  };
+}
+
+describe("useDraftStorage", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("saveDraft 호출 시 localStorage에 저장됨", () => {
+    const { result } = renderHook(() => useDraftStorage<TestForm>(KEY));
+    const draft = { title: "제목", body: "내용" };
+
+    result.current.saveDraft(draft);
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(KEY, JSON.stringify(draft));
+  });
+
+  it("loadDraft 호출 시 저장된 값을 불러옴", () => {
+    const draft = { title: "제목", body: "내용" };
+    localStorage.setItem(KEY, JSON.stringify(draft));
+
+    const { result } = renderHook(() => useDraftStorage<TestForm>(KEY));
+    const loaded = result.current.loadDraft();
+
+    expect(loaded).toEqual(draft);
+  });
+
+  it("clearDraft 호출 시 localStorage에서 삭제됨", () => {
+    const { result } = renderHook(() => useDraftStorage<TestForm>(KEY));
+    result.current.saveDraft({ title: "제목", body: "내용" });
+
+    result.current.clearDraft();
+
+    expect(localStorage.removeItem).toHaveBeenCalledWith(KEY);
+  });
+
+  it("저장된 값이 없으면 null 반환", () => {
+    const { result } = renderHook(() => useDraftStorage<TestForm>(KEY));
+
+    expect(result.current.loadDraft()).toBeNull();
+  });
+});

--- a/src/shared/hooks/record/useDraftStorage.ts
+++ b/src/shared/hooks/record/useDraftStorage.ts
@@ -1,11 +1,16 @@
+import { useCallback } from "react";
+
 export function useDraftStorage<T extends Record<string, unknown>>(
   key: string
 ) {
-  const saveDraft = (values: T) => {
-    localStorage.setItem(key, JSON.stringify(values));
-  };
+  const saveDraft = useCallback(
+    (values: T) => {
+      localStorage.setItem(key, JSON.stringify(values));
+    },
+    [key]
+  );
 
-  const loadDraft = (): Partial<T> | null => {
+  const loadDraft = useCallback((): Partial<T> | null => {
     const raw = localStorage.getItem(key);
     if (!raw) return null;
     try {
@@ -13,9 +18,9 @@ export function useDraftStorage<T extends Record<string, unknown>>(
     } catch {
       return null;
     }
-  };
+  }, [key]);
 
-  const clearDraft = () => localStorage.removeItem(key);
+  const clearDraft = useCallback(() => localStorage.removeItem(key), [key]);
 
   return { saveDraft, loadDraft, clearDraft };
 }

--- a/src/shared/hooks/ui/useInfiniteScroll.test.tsx
+++ b/src/shared/hooks/ui/useInfiniteScroll.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useInfiniteScroll } from "./useInfiniteScroll";
+
+describe("useInfiniteScroll", () => {
+  let ioCreatedCount: number;
+  let observe: ReturnType<typeof vi.fn>;
+  let unobserve: ReturnType<typeof vi.fn>;
+  let capturedCallback: IntersectionObserverCallback;
+
+  beforeEach(() => {
+    ioCreatedCount = 0;
+    observe = vi.fn();
+    unobserve = vi.fn();
+    capturedCallback = () => {};
+
+    class MockIntersectionObserver {
+      constructor(cb: IntersectionObserverCallback) {
+        ioCreatedCount++;
+        capturedCallback = cb;
+      }
+      observe = observe;
+      unobserve = unobserve;
+      disconnect = vi.fn();
+    }
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const triggerIntersection = (isIntersecting: boolean) => {
+    act(() => {
+      capturedCallback(
+        [{ isIntersecting } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      );
+    });
+  };
+
+  it("hasMore=false면 IntersectionObserver가 등록되지 않음", () => {
+    renderHook(() =>
+      useInfiniteScroll({ hasMore: false, isLoading: false, onLoadMore: vi.fn() })
+    );
+
+    expect(ioCreatedCount).toBe(0);
+  });
+
+  it("isLoading=true면 IntersectionObserver가 등록되지 않음", () => {
+    renderHook(() =>
+      useInfiniteScroll({ hasMore: true, isLoading: true, onLoadMore: vi.fn() })
+    );
+
+    expect(ioCreatedCount).toBe(0);
+  });
+
+  it("isLoading=true면 sentinel이 진입해도 onLoadMore가 호출되지 않음", () => {
+    // isLoading=true 상태에서는 Observer 자체가 생성되지 않으므로
+    // intersection이 발생해도 onLoadMore가 호출되지 않는다
+    const onLoadMore = vi.fn();
+    renderHook(() =>
+      useInfiniteScroll({ hasMore: true, isLoading: true, onLoadMore })
+    );
+
+    triggerIntersection(true);
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("sentinel이 화면에 진입하면 onLoadMore가 호출됨", () => {
+    const onLoadMore = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ onLoadMore }: { onLoadMore: () => void }) =>
+        useInfiniteScroll({ hasMore: true, isLoading: false, onLoadMore }),
+      { initialProps: { onLoadMore } }
+    );
+
+    // ref를 DOM 요소에 연결한 뒤 의존성 변경으로 effect 재실행
+    const el = document.createElement("div");
+    result.current.current = el;
+    const onLoadMore2 = vi.fn();
+    rerender({ onLoadMore: onLoadMore2 });
+
+    expect(observe).toHaveBeenCalledWith(el);
+
+    triggerIntersection(true);
+
+    expect(onLoadMore2).toHaveBeenCalledOnce();
+  });
+
+  it("컴포넌트 언마운트 시 observer가 해제됨", () => {
+    const onLoadMore = vi.fn();
+    const { result, rerender, unmount } = renderHook(
+      ({ onLoadMore }: { onLoadMore: () => void }) =>
+        useInfiniteScroll({ hasMore: true, isLoading: false, onLoadMore }),
+      { initialProps: { onLoadMore } }
+    );
+
+    const el = document.createElement("div");
+    result.current.current = el;
+    const onLoadMore2 = vi.fn();
+    rerender({ onLoadMore: onLoadMore2 });
+
+    unmount();
+
+    expect(unobserve).toHaveBeenCalledWith(el);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,7 +79,7 @@
   resolved "https://registry.yarnpkg.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz#ad5549322dfe9d153d4b4dd6f7ff2ae234b06e24"
   integrity sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
   integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
@@ -2095,6 +2095,20 @@
     postcss "^8.4.41"
     tailwindcss "4.1.18"
 
+"@testing-library/dom@^10.4.1":
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"
+  integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.3.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    picocolors "1.1.1"
+    pretty-format "^27.0.2"
+
 "@testing-library/jest-dom@^6.6.3", "@testing-library/jest-dom@^6.9.1":
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz#7613a04e146dd2976d24ddf019730d57a89d56c2"
@@ -2349,6 +2363,11 @@
     "@apollo/client" "^3.7.0"
     "@types/extract-files" "*"
     graphql "14 - 16"
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
 "@types/babel__core@^7.20.5":
   version "7.20.5"
@@ -2926,6 +2945,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 ansi-styles@^6.1.0, ansi-styles@^6.2.1:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
@@ -2949,6 +2973,13 @@ aria-hidden@^1.2.4:
   integrity sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==
   dependencies:
     tslib "^2.0.0"
+
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
 
 aria-query@^5.0.0, aria-query@^5.3.2:
   version "5.3.2"
@@ -3610,6 +3641,11 @@ dependency-graph@^1.0.0:
   resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-1.0.0.tgz#bb5e85aec1310bc13b22dbd76e3196c4ee4c10d2"
   integrity sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==
 
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 detect-indent@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
@@ -3645,6 +3681,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 dom-accessibility-api@^0.6.3:
   version "0.6.3"
@@ -5374,6 +5415,11 @@ lucide-react@^0.563.0:
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.563.0.tgz#9a660d6f009942914a0df42391cf7d7d4dbcc713"
   integrity sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 magic-string@^0.30.0, magic-string@^0.30.11, magic-string@^0.30.21:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
@@ -5852,7 +5898,7 @@ pathval@^2.0.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
   integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
 
-picocolors@^1.0.0, picocolors@^1.1.1:
+picocolors@1.1.1, picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -5920,6 +5966,15 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 promise@^7.1.1:
   version "7.3.1"
@@ -6156,6 +6211,11 @@ react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-remove-scroll-bar@^2.3.7:
   version "2.3.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1587,6 +1587,13 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
+"@playwright/test@^1.59.1":
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.59.1.tgz#5c4d38eac84a61527af466602ae20277685a02d6"
+  integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
+  dependencies:
+    playwright "1.59.1"
+
 "@polka/url@^1.0.0-next.24":
   version "1.0.0-next.29"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
@@ -3706,6 +3713,11 @@ dot-case@^3.0.4:
   dependencies:
     no-case "^3.0.4"
     tslib "^2.0.3"
+
+dotenv@^17.4.2:
+  version "17.4.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.4.2.tgz#c07e54a746e11eba021dd9e1047ced5afdc1c034"
+  integrity sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==
 
 dset@^3.1.2:
   version "3.1.4"
@@ -5920,17 +5932,17 @@ pixelmatch@7.1.0:
   dependencies:
     pngjs "^7.0.0"
 
-playwright-core@1.58.1:
-  version "1.58.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.58.1.tgz#d63be2c9b7dcbdb035beddd4b42437bd3ca89107"
-  integrity sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==
+playwright-core@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
+  integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
 
-playwright@^1.58.1:
-  version "1.58.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.58.1.tgz#63300e77a604c77264e1b499c0d94b54ed96d6ba"
-  integrity sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==
+playwright@1.59.1, playwright@^1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
+  integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
   dependencies:
-    playwright-core "1.58.1"
+    playwright-core "1.59.1"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
## 📌 작업 내용

### 📦 Playwright 환경설정
- @playwright/test 설치 및 playwright.config.ts 설정
- baseURL: http://localhost:3000, 브라우저: chromium
- test:e2e, test:e2e:ui 스크립트 추가

### ✨ 로그아웃 시 refreshToken 쿠키 삭제
- /api/logout 프록시 추가
- 로그아웃 시 서버에서 쿠키를 직접 삭제하도록 처리

### 🐛 임시저장 모달 반복 렌더링 버그 수정
- useDraftStorage를 useCallback 기반으로 리팩토링
- 모든 메서드(saveDraft, loadDraft, clearDraft)의 참조를 안정화
- form.reset() 후 리렌더링 시 함수 참조가 변경되어 모달이 반복 뜨는 문제 해결

### ✅ 유닛 테스트 추가

transformSetCookies 유틸 분리 및 테스트
- pages/api/graphql.ts의 Set-Cookie 가공 로직을 순수 함수로 분리
- Domain 제거, SameSite=Lax, Path=/, Secure 처리 각각 검증

훅 유닛 테스트
- useDraftStorage — localStorage 저장/불러오기/삭제/null 반환/JSON 파싱 실패 처리
- useInfiniteScroll — hasMore/isLoading 가드, sentinel 교차 시 콜백 호출, 언마운트 시 observer 해제

Storybook Provider 보강
- ProfileEntry 컴포넌트 Recoil 의존 제거 (props 기반으로 리팩토링)
- Storybook decorator에 MockedProvider, RecoilRoot, ToastProvider 추가

### ✅ E2E 테스트 추가

인증 플로우 (e2e/auth.spec.ts)
- 로그인 후 refreshToken 쿠키 저장 확인
- 새로고침 후 로그인 유지 확인
- 로그아웃 후 쿠키 삭제 확인
- PasswordField, TextField에 testId 추가

임시저장 플로우 (e2e/draft.spec.ts)
- 임시저장 후 복구 모달 표시 확인
- 복구 후 내용 채워짐 확인
- 복구 후 내용 수정해도 모달이 다시 뜨지 않음 확인 (회귀 방지)
- 취소 후 재진입 시 모달이 뜨지 않음 확인
- 임시저장 없이 진입 시 모달이 뜨지 않음 확인

기록 작성 플로우 (e2e/record.spec.ts)
- 기록 작성 후 목록에 표시 확인
- 필수 항목 미입력 시 유효성 에러 표시 확인
- 기록 수정/삭제 플로우 확인