### PR TITLE
#18 refactor: BottomNav 리디자인 및 Layout 개선

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,17 +7,17 @@ import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 import { RecoilRoot } from "recoil";
 
-type AppComponent = AppProps["Component"] & { noPadding?: boolean };
+type AppComponent = AppProps["Component"] & { noBottomNav?: boolean };
 
 export default function App({ Component, pageProps }: AppProps) {
-  const { noPadding } = Component as AppComponent;
+  const { noBottomNav } = Component as AppComponent;
 
   return (
     <RecoilRoot>
       <ToastProvider>
         <ApolloSetting>
           <AuthInitialize />
-          <Layout noPadding={noPadding}>
+          <Layout noBottomNav={noBottomNav}>
             <Component {...pageProps} />
             <ConfirmModalHost />
           </Layout>

--- a/pages/feelog/[recordId]/edit/index.tsx
+++ b/pages/feelog/[recordId]/edit/index.tsx
@@ -4,4 +4,4 @@ export default function RecordUpdatePage() {
   return <RecordUpdateScreen />;
 }
 
-RecordUpdatePage.noPadding = true;
+RecordUpdatePage.noBottomNav = true;

--- a/pages/feelog/[recordId]/index.tsx
+++ b/pages/feelog/[recordId]/index.tsx
@@ -4,4 +4,4 @@ export default function RecordDetailPage() {
   return <RecordDetailScreen />;
 }
 
-RecordDetailPage.noPadding = true;
+RecordDetailPage.noBottomNav = true;

--- a/pages/feelog/new/index.tsx
+++ b/pages/feelog/new/index.tsx
@@ -4,4 +4,4 @@ export default function NewRecordPage() {
   return <RecordWriteScreen />;
 }
 
-NewRecordPage.noPadding = true;
+NewRecordPage.noBottomNav = true;

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -3,4 +3,3 @@ import LoginScreen from "@/components/features/auth/login/LoginScreen";
 export default function LoginPage() {
   return <LoginScreen />;
 }
-LoginPage.noPadding = true;

--- a/pages/login/signup/index.tsx
+++ b/pages/login/signup/index.tsx
@@ -4,4 +4,3 @@ export default function SignUpPage() {
   return <SignupScreen />;
 }
 
-SignUpPage.noPadding = true;

--- a/pages/user/me/edit/index.tsx
+++ b/pages/user/me/edit/index.tsx
@@ -4,4 +4,4 @@ export default function MyProfileEditPage() {
   return <ProfileEditScreen />;
 }
 
-MyProfileEditPage.noPadding = true;
+MyProfileEditPage.noBottomNav = true;

--- a/src/components/commons/layout/BottomActionBar.tsx
+++ b/src/components/commons/layout/BottomActionBar.tsx
@@ -12,7 +12,7 @@ type Props = {
 export default function BottomActionBar({
   children,
   className,
-  mobileBottomOffsetClassName = "bottom-16",
+  mobileBottomOffsetClassName = "bottom-nav-offset",
   desktopLeftOffsetClassName = "lg:left-[288px]",
 }: Props) {
   return (

--- a/src/components/commons/layout/BottomNav/BottomNav.tsx
+++ b/src/components/commons/layout/BottomNav/BottomNav.tsx
@@ -6,7 +6,7 @@ import Avatar from "@/components/ui/avatar/Avatar";
 import { Button } from "@/components/ui/button/Button";
 import { useNavigation } from "@/shared/hooks/ui/useNavigation";
 import { useConfirmPreset } from "@/shared/hooks/ui/useConfirmPreset";
-import { SIDE_NAV_ITEMS } from "@/shared/constants";
+import { BOTTOM_NAV_ITEMS } from "@/shared/constants";
 import { loggedInUserState } from "@/shared/stores";
 import { useRouter } from "next/router";
 
@@ -30,32 +30,28 @@ export default function BottomNav() {
   };
 
   return (
-    <nav className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-background border-t border-border safe-area-inset-bottom">
-      <div className="grid grid-cols-6 items-center h-16 max-w-2xl mx-auto px-2">
-        {SIDE_NAV_ITEMS.slice(0, 2).map((item) => (
+    <nav className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-background border-t-[1.5px] border-foreground safe-area-inset-bottom">
+      <div className="grid grid-cols-5 items-center h-[50px] max-w-2xl mx-auto px-2">
+        {BOTTOM_NAV_ITEMS.slice(0, 2).map((item) => (
           <BottomNavItem key={item.href} {...item} />
         ))}
         {/* Write (+) */}
-        <div className="relative flex flex-col items-center gap-1 h-full justify-center">
+        <div className="flex items-center justify-center h-full">
           <Button
-            className="size-12 rounded-full -mt-3 shadow-lg hover:shadow-xl hover:scale-105"
+            className="size-11 rounded-full  shadow-lg hover:shadow-xl hover:scale-105"
             onClick={onClickWrite}
           >
-            <Plus className="w-6 h-6" strokeWidth={2.5} />
+            <Plus className="w-5 h-5" strokeWidth={2.5} />
           </Button>
-          <span className="text-xs font-semibold">작성</span>
         </div>
-        {SIDE_NAV_ITEMS.slice(2).map((item) => (
+        {BOTTOM_NAV_ITEMS.slice(2).map((item) => (
           <BottomNavItem key={item.href} {...item} />
         ))}
 
         {isLoggedIn ? (
-          <Link
-            href="/user/me/edit"
-            className="flex flex-1 flex-col items-center justify-center"
-          >
-            <Avatar user={me ?? undefined} size="md" />
-          </Link>
+          <div className="flex items-center justify-center h-full">
+            <Avatar user={me ?? undefined} size="sm" clickable />
+          </div>
         ) : (
           <BottomNavItem href="/login" label="로그인" icon={User} />
         )}

--- a/src/components/commons/layout/BottomNav/BottomNavItem.tsx
+++ b/src/components/commons/layout/BottomNav/BottomNavItem.tsx
@@ -26,10 +26,9 @@ export default function BottomNavItem({
             }
           `}
     >
-      <Icon className="w-6 h-6" />
-      <span className="text-xs">{label}</span>
+      <Icon className="w-5 h-5" />
       {isActive && (
-        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-1 h-1 mb-1 rounded-full bg-primary" />
+        <div className="absolute bottom-[7px] left-1/2 -translate-x-1/2 w-[3px] h-[3px] rounded-full bg-primary" />
       )}
     </Link>
   );

--- a/src/components/commons/layout/Layout.tsx
+++ b/src/components/commons/layout/Layout.tsx
@@ -6,10 +6,13 @@ import SideNav from "./SideNav/SideNav";
 
 interface LayoutProps {
   children: ReactNode;
-  noPadding?: boolean;
+  noBottomNav?: boolean;
 }
 
-export default function Layout({ children, noPadding = false }: LayoutProps) {
+export default function Layout({
+  children,
+  noBottomNav = false,
+}: LayoutProps) {
   return (
     <div className="min-h-screen bg-background text-foreground">
       {/* Desktop Sidebar */}
@@ -29,17 +32,17 @@ export default function Layout({ children, noPadding = false }: LayoutProps) {
 
       {/* Main */}
       <div className="lg:pl-[288px]">
-        <main className="w-full pb-nav lg:pb-0">
-          <div className={noPadding ? "w-full" : "w-full pb-8 lg:pb-8"}>
-            {children}
-          </div>
+        <main className={`w-full lg:pb-0 ${noBottomNav ? "" : "pb-nav"}`}>
+          {children}
         </main>
       </div>
 
       {/* Mobile/Tablet BottomNav */}
-      <div className="lg:hidden">
-        <BottomNav />
-      </div>
+      {!noBottomNav && (
+        <div className="lg:hidden">
+          <BottomNav />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/commons/layout/Layout.tsx
+++ b/src/components/commons/layout/Layout.tsx
@@ -29,14 +29,8 @@ export default function Layout({ children, noPadding = false }: LayoutProps) {
 
       {/* Main */}
       <div className="lg:pl-[288px]">
-        <main className="w-full">
-          <div
-            className={
-              noPadding
-                ? "w-full"
-                : "w-full pb-24 lg:pb-8"
-            }
-          >
+        <main className="w-full pb-nav lg:pb-0">
+          <div className={noPadding ? "w-full" : "w-full pb-8 lg:pb-8"}>
             {children}
           </div>
         </main>

--- a/src/components/features/auth/login/LoginScreen.tsx
+++ b/src/components/features/auth/login/LoginScreen.tsx
@@ -46,7 +46,7 @@ export default function LoginScreen() {
         </div>
 
         {/* 오른쪽 / 모바일 폼 영역 */}
-        <div className="flex-1 flex flex-col items-center px-4 pt-8 pb-16 gap-6 lg:items-start lg:justify-center lg:p-14 lg:border-l-[1.5px] lg:border-foreground">
+        <div className="flex-1 flex flex-col items-center px-4 pt-8 pb-6 gap-6 lg:items-start lg:justify-center lg:p-14 lg:border-l-[1.5px] lg:border-foreground">
           <div className="hidden lg:block w-full">
             <LabelBadge className="mb-4">SIGN IN</LabelBadge>
           </div>

--- a/src/components/features/auth/sign-up/SignupScreen.tsx
+++ b/src/components/features/auth/sign-up/SignupScreen.tsx
@@ -41,7 +41,7 @@ export default function SignupScreen() {
         </div>
 
         {/* 오른쪽 / 모바일 폼 영역 */}
-        <div className="flex-1 flex flex-col items-center px-4 pt-8 pb-16 gap-6 lg:items-start lg:justify-center lg:p-14 lg:border-l-[1.5px] lg:border-foreground">
+        <div className="flex-1 flex flex-col items-center px-4 pt-8 pb-6 gap-6 lg:items-start lg:justify-center lg:p-14 lg:border-l-[1.5px] lg:border-foreground">
           <div className="hidden lg:block w-full">
             <LabelBadge className="mb-4">JOIN US</LabelBadge>
           </div>

--- a/src/components/features/record/editor/ui/RecordEditorForm/RecordEditorForm.tsx
+++ b/src/components/features/record/editor/ui/RecordEditorForm/RecordEditorForm.tsx
@@ -47,7 +47,7 @@ export default function RecordEditorForm({
 
   return (
     <form id={formId} onSubmit={onSubmit}>
-      <div className="pb-40 gap-y-4 ">
+      <div className="pb-40">
         {/* 제목 */}
         <div className="py-4 lg:p-5 border-b border-foreground/15">
           <label htmlFor="title" className={cn(fieldLabel, "text-destructive")}>

--- a/src/components/features/record/list/RecordFeed.tsx
+++ b/src/components/features/record/list/RecordFeed.tsx
@@ -172,7 +172,7 @@ export default function RecordFeed({
         ))}
       </ResponsiveGrid>
 
-      <div ref={sentinelRef} className="h-6" />
+      <div ref={sentinelRef} />
       {isLoading && (
         <div className="p-3 text-muted-foreground">불러오는 중…</div>
       )}

--- a/src/components/features/record/update/ui/RecordUpdateScreenSkeleton.tsx
+++ b/src/components/features/record/update/ui/RecordUpdateScreenSkeleton.tsx
@@ -63,7 +63,7 @@ export default function RecordUpdateScreenSkeleton(): JSX.Element {
       </div>
 
       {/* BottomActionBar */}
-      <div className="fixed left-0 right-0 z-40 bottom-16 lg:bottom-0 lg:right-0 lg:left-[288px] border-t-[1.5px] border-foreground bg-background">
+      <div className="fixed left-0 right-0 z-40 bottom-nav-offset lg:bottom-0 lg:right-0 lg:left-[288px] border-t-[1.5px] border-foreground bg-background">
         <div className="mx-auto w-full max-w-lg px-4 pt-4 pb-[calc(env(safe-area-inset-bottom,0px)+16px)]">
           <div className="flex gap-3">
             <Shimmer className="flex-1 h-11 rounded" />

--- a/src/shared/constants/navigation.ts
+++ b/src/shared/constants/navigation.ts
@@ -12,5 +12,16 @@ export const SIDE_NAV_ITEMS = [
   icon: LucideIcon;
 }>;
 
+export const BOTTOM_NAV_ITEMS = [
+  { tab: "home", href: "/", label: "Home", icon: Home },
+  { tab: "feelog", href: "/feelog", label: "Feed", icon: LayoutGrid },
+  { tab: "shows", href: "/shows", label: "Shows", icon: Search },
+] as const satisfies ReadonlyArray<{
+  tab: string;
+  label: string;
+  href: string;
+  icon: LucideIcon;
+}>;
+
 export type TabType = (typeof SIDE_NAV_ITEMS)[number]["tab"];
 export type SideNavItemType = (typeof SIDE_NAV_ITEMS)[number];

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -47,6 +47,18 @@
   }
 } */
 
+:root {
+  --bottom-nav-height: 50px;
+}
+
+@utility bottom-nav-offset {
+  bottom: var(--bottom-nav-height);
+}
+
+@utility pb-nav {
+  padding-bottom: var(--bottom-nav-height);
+}
+
 body {
   font-family: "Pretendard Variable", Pretendard, Inter, ui-sans-serif, system-ui, sans-serif;
 }


### PR DESCRIPTION
✨[Feat] BottomNav 리디자인 및 Layout 개선

## 변경 사항

### BottomNav 리디자인
- 라벨 제거, 높이 50px로 축소
- My Log 탭 제거, 아바타로 대체

### CSS 변수 기반 높이 관리
- `--bottom-nav-height` CSS 변수 추가
- `pb-nav`, `bottom-nav-offset` @utility 클래스 추가
- Layout에서 BottomNav padding 통합 관리

### Layout 구조 개선
- `noPadding` prop 제거 (각 화면이 자체 레이아웃 관리)
- `noBottomNav` prop 추가
- PageHeader가 있는 화면에서 BottomNav 자동 숨김 적용

### noBottomNav 적용 페이지
- RecordDetail, RecordWrite, RecordUpdate
- ShowDetail, ProfileEdit

## 관련 이슈
closes #18 