### PR TITLE
✨[Feat] 관심 공연 찜하기 기능 구현

### DIFF
--- a/src/components/commons/card/RecordPosterCard/RecordPosterCardMeta.tsx
+++ b/src/components/commons/card/RecordPosterCard/RecordPosterCardMeta.tsx
@@ -1,6 +1,7 @@
 import { RecordSummary } from "@/api/adapters/types/record-summary";
 import Avatar from "@/components/ui/avatar/Avatar";
-import { CommentIcon, HeartIcon } from "@/components/ui/icons";
+import LikeButton from "@/components/ui/button/LikeButton";
+import { CommentIcon } from "@/components/ui/icons";
 import { useLikeRecord } from "@/shared/hooks/record/useLikeRecord";
 
 export default function RecordPosterCardMeta({
@@ -19,20 +20,12 @@ export default function RecordPosterCardMeta({
           {record.user?.name}
         </span>
         <div className="flex items-center gap-3">
-          <HeartIcon
+          <LikeButton
             likeCount={record.likeCount}
             isLiked={record.isLiked ?? false}
-            iconSize="xs"
-            direction="row"
-            iconColor="primary"
             onToggle={() => onLikeRecord(record.id)}
           />
-          <CommentIcon
-            count={record.commentCount ?? 0}
-            iconSize="xs"
-            direction="row"
-            className="text-foreground/70"
-          />
+          <CommentIcon count={record.commentCount ?? 0} />
         </div>
       </div>
     </div>

--- a/src/components/commons/card/ShowCard/ShowCardMeta.tsx
+++ b/src/components/commons/card/ShowCard/ShowCardMeta.tsx
@@ -1,7 +1,9 @@
-import { Bookmark } from "lucide-react";
 import { Performance } from "@/shared/types/performance";
+import LikeButton from "@/components/ui/button/LikeButton";
+import { useToggleShowLike } from "@/shared/hooks/show/useToggleShowLike";
 
 export default function ShowCardMeta({ p }: { p: Performance }) {
+  const { toggle, loading } = useToggleShowLike();
   return (
     <div
       className="
@@ -29,14 +31,11 @@ export default function ShowCardMeta({ p }: { p: Performance }) {
             </span>
           </div>
         )}
-        {/* TODO: 관심공연 찜 기능 연결 */}
-        <button
-          type="button"
-          className="flex items-center text-muted-foreground hover:text-point transition-colors ml-4 @card-md:ml-6"
-        >
-          {/* TODO: 북마크 아이콘 리팩토링 */}
-          <Bookmark className="w-3 h-3  @card-sm:w-4 @card-sm:h-4 @card-md:w-4.5 @card-md:h-4.5" />
-        </button>
+        <LikeButton
+          isLiked={false}
+          onToggle={() => toggle(p.mt20id)}
+          className="ml-4 @card-md:ml-6"
+        />
       </div>
 
       {/* Row 2: 공연 제목 */}

--- a/src/components/ui/button/LikeButton.stories.tsx
+++ b/src/components/ui/button/LikeButton.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { CARD_CQ_WIDTHS } from "@/storybook/constants";
+import LikeButton from "./LikeButton";
+
+const meta: Meta<typeof LikeButton> = {
+  title: "ui/button/LikeButton",
+  component: LikeButton,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    isLiked: { control: "boolean" },
+    likeCount: { control: "number" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LikeButton>;
+
+export const NotLiked: Story = {
+  decorators: [
+    (Story) => (
+      <div className="@container" style={{ width: 280 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: { isLiked: false, likeCount: 12 },
+};
+
+export const Liked: Story = {
+  decorators: [
+    (Story) => (
+      <div className="@container" style={{ width: 280 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: { isLiked: true, likeCount: 12 },
+};
+
+export const NoCount: Story = {
+  decorators: [
+    (Story) => (
+      <div className="@container" style={{ width: 280 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: { isLiked: false },
+};
+
+// CQ 사이즈 케이스
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {CARD_CQ_WIDTHS.map(({ label, desc, width }) => (
+        <div key={label} className="flex items-center gap-4">
+          <span className="w-28 shrink-0 text-xs text-muted-foreground">
+            {desc} ({label})
+          </span>
+          <div className="@container flex items-center gap-4" style={{ width }}>
+            <LikeButton isLiked={false} likeCount={12} />
+            <LikeButton isLiked={true} likeCount={12} />
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/src/components/ui/button/LikeButton.tsx
+++ b/src/components/ui/button/LikeButton.tsx
@@ -1,0 +1,65 @@
+// import { ICON_COLOR, IconColor, IconSize, ICON_SIZE } from "@/shared/tokens";
+import { cn } from "@/shared/utils";
+import { Heart } from "lucide-react";
+import { JSX, useEffect, useState } from "react";
+
+type LikeButtonProps = {
+  isLiked: boolean;
+  onToggle?: (nextLiked: boolean) => void;
+  likeCount?: number;
+  className?: string;
+};
+
+export default function LikeButton({
+  isLiked,
+  onToggle,
+  likeCount,
+  className,
+}: LikeButtonProps): JSX.Element {
+  const [liked, setLiked] = useState(isLiked);
+  const [likes, setLikes] = useState(likeCount ?? 0);
+
+  useEffect(() => {
+    setLiked(isLiked);
+  }, [isLiked]);
+  useEffect(() => {
+    setLikes(likeCount ?? 0);
+  }, [likeCount]);
+
+  const handleClick = (e: React.MouseEvent): void => {
+    e.stopPropagation();
+    const nextLiked = !liked;
+    setLikes((prev) => (liked ? prev - 1 : prev + 1));
+    setLiked(nextLiked);
+    onToggle?.(nextLiked);
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className={cn(
+        "flex items-center transition-colors group/like gap-1 ",
+        className,
+      )}
+      aria-label="좋아요"
+    >
+      <Heart
+        className={cn(
+          "w-3 h-3  @card-sm:w-4 @card-sm:h-4 @card-md:w-4.5 @card-md:h-4.5 transition-colors",
+          liked ? "text-point" : "text-muted-foreground",
+        )}
+        fill={liked ? "currentColor" : "none"}
+      />
+      {likeCount !== undefined && (
+        <span
+          className={cn(
+            `text-[10px] @card-sm:text-xs @card-md:text-base`,
+            liked ? "text-point" : "text-muted-foreground",
+          )}
+        >
+          {likes}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/components/ui/icons/commentIcon/CommentIcon.stories.tsx
+++ b/src/components/ui/icons/commentIcon/CommentIcon.stories.tsx
@@ -1,22 +1,54 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { CARD_CQ_WIDTHS } from "@/storybook/constants";
 import CommentIcon from "./CommentIcon";
 
 const meta: Meta<typeof CommentIcon> = {
-  title: "commons/ui/icons/CommentIcon",
+  title: "ui/icons/CommentIcon",
   component: CommentIcon,
-  parameters: { layout: "fullscreen" },
-  decorators: [
-    (Story) => (
-      <div className="min-h-screen w-screen bg-gray-900 flex items-center justify-center p-6">
-        <Story />
-      </div>
-    ),
-  ],
+  parameters: { layout: "centered" },
+  argTypes: {
+    count: { control: "number" },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof CommentIcon>;
 
 export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div className="@container" style={{ width: 280 }}>
+        <Story />
+      </div>
+    ),
+  ],
   args: { count: 12 },
+};
+
+export const NoCount: Story = {
+  decorators: [
+    (Story) => (
+      <div className="@container" style={{ width: 280 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {},
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {CARD_CQ_WIDTHS.map(({ label, desc, width }) => (
+        <div key={label} className="flex items-center gap-4">
+          <span className="w-28 shrink-0 text-xs text-muted-foreground">
+            {desc} ({label})
+          </span>
+          <div className="@container" style={{ width }}>
+            <CommentIcon count={12} />
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
 };

--- a/src/components/ui/icons/commentIcon/CommentIcon.tsx
+++ b/src/components/ui/icons/commentIcon/CommentIcon.tsx
@@ -1,32 +1,25 @@
-import { ICON_SIZE, IconSize } from "@/shared/tokens";
 import { cn } from "@/shared/utils";
 import { MessageCircle } from "lucide-react";
 import { JSX } from "react";
 
+type CommentIconProps = {
+  count?: number;
+  className?: string;
+};
+
 export default function CommentIcon({
   count,
-  iconSize = "sm",
-  direction = "col",
   className,
-}: {
-  count: number;
-  iconSize?: IconSize;
-  direction?: "col" | "row";
-  className?: string;
-}): JSX.Element {
-  const s = ICON_SIZE[iconSize];
-
-  const isRow = direction === "row";
+}: CommentIconProps): JSX.Element {
   return (
     <div
-      className={cn(
-        "flex items-center transition-colors group/like",
-        isRow ? `flex-row ${s.gapRow}` : `flex-col ${s.gapCol}`,
-        className
-      )}
+      className={cn("flex items-center transition-colors  gap-1", className)}
+      aria-label="댓글"
     >
-      <MessageCircle className={cn(s.icon, className)} />
-      <span className={cn(s.text, className)}>{count}</span>
+      <MessageCircle className="w-3 h-3 @card-sm:w-4 @card-sm:h-4 @card-md:w-4.5 @card-md:h-4.5 transition-colors text-muted-foreground" />
+      <span className="text-[10px] @card-sm:text-xs @card-md:text-base text-muted-foreground">
+        {count ?? 0}
+      </span>
     </div>
   );
 }

--- a/src/shared/hooks/show/useSubscribedShows.ts
+++ b/src/shared/hooks/show/useSubscribedShows.ts
@@ -1,0 +1,22 @@
+import { gql, useQuery } from "@apollo/client";
+import { IQuery } from "@/api/graphql/generated/types.new";
+
+const FETCH_SUBSCRIBED_PERFORMANCES = gql`
+  query fetchSubscribedPerformances {
+    fetchSubscribedPerformances
+  }
+`;
+
+export function useSubscribedShows() {
+  const { data, loading } = useQuery<
+    Pick<IQuery, "fetchSubscribedPerformances">
+  >(FETCH_SUBSCRIBED_PERFORMANCES, {
+    fetchPolicy: "cache-and-network",
+  });
+
+  const subscribedIds = data?.fetchSubscribedPerformances ?? [];
+
+  const isSubscribed = (mt20id: string) => subscribedIds.includes(mt20id);
+
+  return { subscribedIds, isSubscribed, loading };
+}

--- a/src/shared/hooks/show/useToggleShowLike.ts
+++ b/src/shared/hooks/show/useToggleShowLike.ts
@@ -1,0 +1,27 @@
+import { gql, useMutation } from "@apollo/client";
+import {
+  IMutation,
+  IMutationTogglePerformanceSubscriptionArgs,
+} from "@/api/graphql/generated/types.new";
+
+const TOGGLE_PERFORMANCE_SUBSCRIPTION = gql`
+  mutation togglePerformanceSubscription($mt20id: String!) {
+    togglePerformanceSubscription(mt20id: $mt20id)
+  }
+`;
+
+export function useToggleShowLike() {
+  const [toggleMutation, { loading }] = useMutation<
+    Pick<IMutation, "togglePerformanceSubscription">,
+    IMutationTogglePerformanceSubscriptionArgs
+  >(TOGGLE_PERFORMANCE_SUBSCRIPTION, {
+    refetchQueries: ["fetchSubscribedPerformances"],
+  });
+
+  const toggle = async (mt20id: string) => {
+    const result = await toggleMutation({ variables: { mt20id } });
+    return result.data?.togglePerformanceSubscription;
+  };
+
+  return { toggle, loading };
+}


### PR DESCRIPTION
## 관련 이슈
close #24

## 작업 내용

### 훅
- `useSubscribedShows` — `fetchSubscribedPerformances` 기반 찜한 공연 목록 조회 훅
- `useToggleShowLike` — `togglePerformanceSubscription` 뮤테이션 훅 (refetchQueries 포함)

### 컴포넌트
- `LikeButton` 공통 컴포넌트 구현 — Container Query 기반 아이콘 사이즈, liked 상태 UI
- `ShowCardMeta` / `RecordCardMeta`에 LikeButton + 훅 연결
- `CommentIcon` CQ 적용 (`@card-sm`, `@card-md` 사이즈 대응)

### 스토리북
- `LikeButton.stories.tsx` 추가 (liked/unliked, 카운트 유무, CQ 사이즈 케이스)
- `CommentIcon.stories.tsx` 업데이트

---

## 이슈 대비 미완료 항목

| 완료 기준 | 상태 | 비고 |
|---|---|---|
| ShowCard · 공연 상세페이지에 저장 버튼 표시 | ⏳ 부분 완료 | LikeButton은 구현됨. 찜 상태(`isSaved`) 표시는 백엔드 API 추가 후 진행 (#66) |
| 저장/해제 동작 및 상태 반영 | ✅ | `useToggleShowLike` 구현 완료 |
| 마이페이지에서 저장 목록 접근 | ⏳ 부분 완료 | `useSubscribedShows` 구현 완료. 마이페이지 UI 연결은 별도 진행 예정(#63)  |

ShowCard · ShowDetail의 찜 상태 표시는 백엔드에 `isPerformanceSubscribed(mt20id: ID!): Boolean` 쿼리 추가 후 #66에서 완성 예정.