### PR TITLE
#63 유저 프로필 페이지 찜한 공연 그리드 구현

### DIFF
--- a/src/components/features/shows/detail/hooks/useFetchShowDetail.ts
+++ b/src/components/features/shows/detail/hooks/useFetchShowDetail.ts
@@ -2,7 +2,7 @@ import type { PerformanceDetail } from "@/shared/types/performance";
 import { queryKeys } from "@/api/rest/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
-async function fetchShowDetail(id: string): Promise<PerformanceDetail> {
+export async function fetchShowDetail(id: string): Promise<PerformanceDetail> {
   const res = await fetch(`/api/kopis/performances/${encodeURIComponent(id)}`);
   if (!res.ok) {
     throw new Error(`Failed to fetch show detail: ${res.status}`);

--- a/src/components/features/user/hooks/query/index.ts
+++ b/src/components/features/user/hooks/query/index.ts
@@ -6,3 +6,4 @@ export { useFetchCountOfFollowers } from "./useFetchCountOfFollowers";
 export { useFetchCountOfFollowing } from "./useFetchCountOfFollowing";
 export { useFetchFollowers } from "./useFetchFollowers";
 export { useFetchFollowing } from "./useFetchFollowing";
+export { useFetchSavedShows } from "./useFetchSavedShows";

--- a/src/components/features/user/hooks/query/useFetchSavedShows.ts
+++ b/src/components/features/user/hooks/query/useFetchSavedShows.ts
@@ -1,0 +1,28 @@
+import { queryKeys } from "@/api/rest/queryKeys";
+import { fetchShowDetail } from "@/components/features/shows/detail/hooks/useFetchShowDetail";
+import { useFetchSubscribedShowIds } from "@/shared/hooks/show/useFetchSubscribedShowIds";
+import { PerformanceDetail } from "@/shared/types/performance";
+import { useQueries } from "@tanstack/react-query";
+
+export const useFetchSavedShows = () => {
+  const {
+    subscribedIds,
+    loading: idsLoading,
+    error,
+  } = useFetchSubscribedShowIds();
+
+  const results = useQueries({
+    queries: subscribedIds.map((id) => ({
+      queryKey: queryKeys.kopis.performanceDetail(id),
+      queryFn: () => fetchShowDetail(id),
+      enabled: !idsLoading,
+    })),
+  });
+
+  const shows = results
+    .map((r) => r.data)
+    .filter((d): d is PerformanceDetail => !!d);
+  const loading = idsLoading || results.some((r) => r.isLoading);
+
+  return { shows, loading, error };
+};

--- a/src/components/features/user/ui/component/user-content-grid/UserSavedShowGrid.tsx
+++ b/src/components/features/user/ui/component/user-content-grid/UserSavedShowGrid.tsx
@@ -1,9 +1,12 @@
+import { Sparkles } from "lucide-react";
+import { ResponsiveGrid } from "@/components/commons/layout";
 import { CardGridSkeleton } from "@/components/ui/feedback";
-import { useSubscribedShows } from "@/shared/hooks/show/useSubscribedShows";
+import ShowCard from "@/components/commons/card/ShowCard/ShowCard";
+import { useFetchSavedShows } from "../../../hooks";
 
 export default function UserSavedShowGrid() {
-  const { subscribedIds, loading } = useSubscribedShows();
-  //  TODO:
+  const { shows, loading, error } = useFetchSavedShows();
+
   if (loading) {
     return (
       <CardGridSkeleton
@@ -14,11 +17,37 @@ export default function UserSavedShowGrid() {
       />
     );
   }
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 py-5 text-muted-foreground">
+        <Sparkles className="h-5 w-5" />
+        <span className="text-sm">
+          찜한 공연을 불러오는 중 오류가 발생했어요
+        </span>
+      </div>
+    );
+  }
+
+  if (shows.length === 0) {
+    return (
+      <div className="flex items-center gap-2 py-5 text-muted-foreground">
+        <Sparkles className="h-5 w-5" />
+        <span className="text-sm">찜한 공연이 없어요</span>
+      </div>
+    );
+  }
+
   return (
-    <div>
-      {subscribedIds.map((s) => (
-        <p key={s}>{s}</p>
+    <ResponsiveGrid
+      cols={2}
+      colsMd={3}
+      colsLg={4}
+      bordered
+      className="border-t-0"
+    >
+      {shows.map((show) => (
+        <ShowCard key={show.mt20id} performance={show} showBorder />
       ))}
-    </div>
+    </ResponsiveGrid>
   );
 }

--- a/src/components/features/user/ui/screen/UserProfileScreen.tsx
+++ b/src/components/features/user/ui/screen/UserProfileScreen.tsx
@@ -82,7 +82,7 @@ export default function UserProfileScreen({
         />
         {activeTab === "records" && <UserRecordGrid userId={userId} />}
         {activeTab === "liked" && <UserLikedRecordGrid userId={userId} />}
-        {/* {activeTab === "saved" && <UserSavedShowGrid />} */}
+        {activeTab === "saved" && <UserSavedShowGrid />}
       </section>
     </ResponsiveLayout>
   );

--- a/src/shared/hooks/show/useFetchSubscribedShowIds.ts
+++ b/src/shared/hooks/show/useFetchSubscribedShowIds.ts
@@ -1,16 +1,16 @@
 import { gql, useQuery } from "@apollo/client";
 import { IQuery } from "@/api/graphql/generated/types.new";
 
-const FETCH_SUBSCRIBED_PERFORMANCES = gql`
+const FETCH_SUBSCRIBED_PERFORMANCE_IDS = gql`
   query fetchSubscribedPerformances {
     fetchSubscribedPerformances
   }
 `;
 
-export function useSubscribedShows() {
-  const { data, loading } = useQuery<
+export function useFetchSubscribedShowIds() {
+  const { data, loading, error } = useQuery<
     Pick<IQuery, "fetchSubscribedPerformances">
-  >(FETCH_SUBSCRIBED_PERFORMANCES, {
+  >(FETCH_SUBSCRIBED_PERFORMANCE_IDS, {
     fetchPolicy: "cache-and-network",
   });
 
@@ -18,5 +18,5 @@ export function useSubscribedShows() {
 
   const isSubscribed = (mt20id: string) => subscribedIds.includes(mt20id);
 
-  return { subscribedIds, isSubscribed, loading };
+  return { subscribedIds, isSubscribed, loading, error };
 }


### PR DESCRIPTION
## 관련 이슈
close #63 

## 작업 내용

- `useFetchSavedShows` 훅 구현
  - `useFetchSubscribedShowIds`로 찜한 공연 mt20id 배열 조회
  - `useQueries`로 각 공연 상세 병렬 호출 (`/api/kopis/performances/:id`)
  - `fetchShowDetail` 재사용 (기존 `useFetchShowDetail`에서 export)
- `UserSavedShowGrid` 컴포넌트 구현
  - 로딩 스켈레톤 처리
  - 에러 상태 UI 처리
  - 빈 상태(찜한 공연 없음) UI 처리
  - `ShowCard` + `ResponsiveGrid`로 그리드 표시
- `UserProfileScreen` "찜한 공연" 탭 활성화