### PR TITLE
76 refactor usesearch 훅 도입 및 searchbar 입력 상태 관리 개선

### DIFF
--- a/src/components/commons/search/SearchBar.stories.tsx
+++ b/src/components/commons/search/SearchBar.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
 import SearchBar from "./SearchBar";
+import { useSearch } from "./useSearch";
 
 const meta: Meta<typeof SearchBar> = {
   title: "commons/SearchBar",
@@ -11,7 +13,7 @@ const meta: Meta<typeof SearchBar> = {
         className="min-h-screen w-screen p-8"
         style={{ background: "#0B1220" }}
       >
-        <div className="mx-auto w-full max-w-xl rounded-2xl border border-white/10 bg-white/5 p-6">
+        <div className="mx-auto w-full max-w-xl rounded-2xl border border-white/10 bg-white/5 p-6 space-y-4">
           <Story />
         </div>
       </div>
@@ -22,10 +24,75 @@ const meta: Meta<typeof SearchBar> = {
 export default meta;
 type Story = StoryObj<typeof SearchBar>;
 
+function OnlySearchDemo() {
+  const [committed, setCommitted] = useState<string | null>(null);
+  const { search, setSearch, submit, reset } = useSearch({
+    initValue: { search: "" },
+    onCommit: (values) => setCommitted(JSON.stringify(values, null, 2)),
+  });
+
+  return (
+    <>
+      <SearchBar
+        variant="onlySearch"
+        search={search}
+        onSearchChange={setSearch}
+        onSubmit={submit}
+        onReset={reset}
+      />
+      <div className="rounded border border-white/10 bg-white/5 p-3 text-xs text-white/60">
+        <p className="mb-1 font-bold text-white/40">
+          committed (Search 클릭 후 반영)
+        </p>
+        <pre>{committed ?? "—"}</pre>
+      </div>
+    </>
+  );
+}
+
+function WithDateDemo() {
+  const [committed, setCommitted] = useState<string | null>(null);
+  const {
+    search,
+    setSearch,
+    startDate,
+    setStartDate,
+    endDate,
+    setEndDate,
+    submit,
+    reset,
+  } = useSearch({
+    initValue: { search: "", startDate: "", endDate: "" },
+    onCommit: (values) => setCommitted(JSON.stringify(values, null, 2)),
+  });
+
+  return (
+    <>
+      <SearchBar
+        variant="withDate"
+        search={search}
+        onSearchChange={setSearch}
+        startDate={startDate}
+        endDate={endDate}
+        onStartDateChange={setStartDate}
+        onEndDateChange={setEndDate}
+        onSubmit={submit}
+        onReset={reset}
+      />
+      <div className="rounded border border-white/10 bg-white/5 p-3 text-xs text-white/60">
+        <p className="mb-1 font-bold text-white/40">
+          committed (Search 클릭 후 반영)
+        </p>
+        <pre>{committed ?? "—"}</pre>
+      </div>
+    </>
+  );
+}
+
 export const OnlySearch: Story = {
-  args: { variant: "onlySearch" },
+  render: () => <OnlySearchDemo />,
 };
 
 export const WithDate: Story = {
-  args: { variant: "withDate" },
+  render: () => <WithDateDemo />,
 };

--- a/src/components/commons/search/SearchBar.tsx
+++ b/src/components/commons/search/SearchBar.tsx
@@ -7,6 +7,7 @@ type SearchBarBaseProps = {
   search: string;
   onSearchChange: (v: string) => void;
   onSubmit?: () => void;
+  onReset?: () => void;
 };
 
 type SearchBarOnlySearchProps = SearchBarBaseProps & {
@@ -27,7 +28,7 @@ const submitButtonClass =
   "h-14 bg-foreground text-xs font-black uppercase tracking-[0.12em] text-background transition-opacity hover:opacity-80 active:opacity-70";
 
 export default function SearchBar(props: SearchBarProps): JSX.Element {
-  const { variant, search, onSearchChange, onSubmit } = props;
+  const { variant, search, onSearchChange, onSubmit, onReset } = props;
 
   const [activeField, setActiveField] = useState<"from" | "to" | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -71,7 +72,7 @@ export default function SearchBar(props: SearchBarProps): JSX.Element {
         className="grid h-14 w-full border-[1.5px] border-foreground bg-card grid-cols-[1fr_92px]"
       >
         <div className="flex h-14 items-center gap-3 border-r border-border px-4">
-          <SearchInput value={search} onChange={onSearchChange} />
+          <SearchInput value={search} onChange={onSearchChange} onReset={onReset} />
         </div>
         <button type="submit" className={submitButtonClass}>
           Search
@@ -97,7 +98,7 @@ export default function SearchBar(props: SearchBarProps): JSX.Element {
             "border-b border-border md:border-b-0 md:border-r",
           ].join(" ")}
         >
-          <SearchInput value={search} onChange={onSearchChange} />
+          <SearchInput value={search} onChange={onSearchChange} onReset={onReset} />
         </div>
 
         <DatePickerCell

--- a/src/components/commons/search/SearchInput.tsx
+++ b/src/components/commons/search/SearchInput.tsx
@@ -3,12 +3,14 @@ import { Search, X } from "lucide-react";
 type Props = {
   value: string;
   onChange: (v: string) => void;
+  onReset?: () => void;
   placeholder?: string;
 };
 
 export default function SearchInput({
   value,
   onChange,
+  onReset,
   placeholder = "공연, 아티스트 검색",
 }: Props) {
   return (
@@ -27,7 +29,7 @@ export default function SearchInput({
       {value && (
         <button
           type="button"
-          onClick={() => onChange("")}
+          onClick={() => onReset ? onReset() : onChange("")}
           aria-label="검색어 초기화"
           className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
         >

--- a/src/components/commons/search/useSearch.ts
+++ b/src/components/commons/search/useSearch.ts
@@ -1,0 +1,40 @@
+import { useCallback, useState } from "react";
+
+type SearchArgs = {
+  search: string;
+  startDate?: string;
+  endDate?: string;
+};
+
+type SearchProps = {
+  initValue: SearchArgs;
+  onCommit: (values: SearchArgs) => void;
+};
+
+export function useSearch({ initValue: init, onCommit }: SearchProps) {
+  const [search, setSearch] = useState(init.search);
+  const [startDate, setStartDate] = useState(init.startDate ?? "");
+  const [endDate, setEndDate] = useState(init.endDate ?? "");
+
+  const submit = useCallback(() => {
+    onCommit({ search, startDate, endDate });
+  }, [search, startDate, endDate, onCommit]);
+
+  const reset = useCallback(() => {
+    setSearch("");
+    setStartDate("");
+    setEndDate("");
+    onCommit({ search: "", startDate: "", endDate: "" });
+  }, [onCommit]);
+
+  return {
+    search,
+    setSearch,
+    startDate,
+    setStartDate,
+    endDate,
+    setEndDate,
+    submit,
+    reset,
+  };
+}


### PR DESCRIPTION
## 개요

`useSearch` 훅을 도입하여 SearchBar의 입력 상태 관리를 개선합니다.
기존에는 각 feature 화면에서 검색어/날짜 state를 직접 관리했으나, 로컬 state로 분리하고 Search 버튼 클릭 시에만 commit하는 방식으로 변경합니다.

close #76

## 작업 내용

### `useSearch` 훅 구현 (`commons/search/useSearch.ts`)
- 검색어, 날짜(`startDate`, `endDate`) 입력 상태 로컬 관리
- `submit` — 현재 입력값을 `onCommit`으로 전달 (Search 버튼 연결)
- `reset` — 전체 초기화 후 즉시 `onCommit` 호출 (검색어 X 버튼 연결)
- URL 업데이트 등 side effect는 `onCommit`에서 처리 (관심사 분리)

### UX 스펙
| 액션 | URL 반영 시점 |
|---|---|
| 검색어 입력 | Search 버튼 클릭 시 |
| 검색어 X | 즉시 (전체 초기화) |
| From/To 날짜 선택 | Search 버튼 클릭 시 |
| From/To × | Search 버튼 클릭 시 |
| Search 버튼 | 즉시 |

### `SearchInput`, `SearchBar` 수정
- `onReset` prop 추가 — X 버튼 클릭 시 `useSearch.reset` 연결

### `SearchBar.stories.tsx` 업데이트
- `useSearch` 연동한 인터랙티브 Demo로 교체
- committed 값 실시간 확인 가능 (Search 클릭 전후 비교)